### PR TITLE
Change to use member function for performance

### DIFF
--- a/models/resources/Collection.cfc
+++ b/models/resources/Collection.cfc
@@ -20,8 +20,9 @@ component extends="cffractal.models.resources.AbstractResource" {
         }
 
         var transformedDataArray = [];
-        for ( var value in data ) {
-            var transformedItem = processItem( scope, value );
+        
+        data.each( function( value ){
+        	var transformedItem = processItem( scope, value );
             for ( var callback in postTransformationCallbacks ) {
                 transformedItem = paramNull(
                     callback(
@@ -36,7 +37,8 @@ component extends="cffractal.models.resources.AbstractResource" {
                 transformedDataArray,
                 transformedItem
             );
-        }
+        } );
+        
         return transformedDataArray;
     }
 


### PR DESCRIPTION
Transformations on complex ORM objects with many relationships consistently show about a 25-30% decrease in collection assembly times when using member functions (on ACF) instead of for/in