### PR TITLE
Add XMLSerializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 6.0.0
+
+### Breaking Changes
+
++ Custom `Serializers` now need to implement two additional methods:
+	+ `scopeData` — Decides how to nest the data under the given identifier. Most implementations will return the current data under the last identifier: `{ "#listLast( arguments.identifier, "." )#" = data };`
+	+ `scopeRootKey` — Decides which key to use (if any) for the root of the serialized data.
++ Transformers can set a `resourceKey` property to be used if the transformer is the root transformer in certain serializers. (`variables.resourceKey = "book";`)  For instance, this property is used in the `XMLSerializer` to set the root node name.  If no `resourceKey` is set, or a callback transfomer is used, a default `resourceKey` of `data` will be used.

--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -21,6 +21,8 @@ component {
             .to( "#moduleMapping#.models.serializers.DataSerializer" );
         binder.map( "ResultsMapSerializer@cffractal" ).asSingleton()
             .to( "#moduleMapping#.models.serializers.ResultsMapSerializer" );
+        binder.map( "XMLSerializer@cffractal" ).asSingleton()
+            .to( "#moduleMapping#.models.serializers.XMLSerializer" );
 
         binder.map( "Manager@cffractal" )
             .to( "#moduleMapping#.models.Manager" )

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ A Serializer is responsible for the shape of the response, both the data and the
 
 Perhaps you always want your data nested under a `data` key for consistency.  Maybe you want to separate the `results` as an array of ids from the `resultsMap` which is the data keyed by the id.  You might want a `metadata` key always present for any additional information, like pagination, that doesn't fit inside the normal data keys.  Whatever the shape, you can design a serializer that can produce it.
 
-A serialzier needs two methods:
+A serializer needs four methods:
 
 > ##### `data`
 
@@ -183,7 +183,7 @@ A serialzier needs two methods:
 
 > | Name | Type | Required | Default | Description |
 > | --- | --- | --- | --- | --- | 
-> | resource | AbstractResource | true | | The fractal resource to process and serailize. |
+> | resource | AbstractResource | true | | The fractal resource to process and serialize. |
 > | scope | Scope | true | | The current scope instance.  Included to pass along to the resource during processing. |
 
 
@@ -193,12 +193,32 @@ A serialzier needs two methods:
 
 > | Name | Type | Required | Default | Description |
 > | --- | --- | --- | --- | --- | 
-> | resource | AbstractResource | true | | The fractal resource to process and serailize. |
+> | resource | AbstractResource | true | | The fractal resource to process and serialize. |
 > | scope | Scope | true | | The current scope instance.  Included to pass along to the resource during processing. |
 
-A default serializer is configured for the application when creating the Fractal manager.  Unless overridden, this is the serializer used for each scope in the serialization processes.
+ 
+> ##### `scopeData`
 
-The current serializer for the Manager can be retrieved at any time by calling `getSerializer`.  Additionally, a new default serializer can be set on the Manager by calling `setSerializer`.
+> Decides how to nest the data under the given identifier.
+
+> | Name | Type | Required | Default | Description |
+> | --- | --- | --- | --- | --- | 
+> | data | any | true | | The serialized data. |
+> | identifier | string | true | | The current identifier for the serialization process. |
+
+
+> ##### `scopeRootKey`
+
+> Decides which key to use (if any) for the root of the serialized data.
+
+> | Name | Type | Required | Default | Description |
+> | --- | --- | --- | --- | --- | 
+> | data | any | true | | The serialized data. |
+> | identifier | string | true | | The current identifier for the serialization process. |
+
+A default serializer is configured for the application when creating the Fractal manager for both `items` and `collections`.  These can be configured separately  Unless overridden, this is the serializer used for each scope in the serialization processes.
+
+The current serializer for the Manager can be retrieved at any time by calling `getItemSerializer` and `getCollectionSerializer`.  Additionally, a new default serializer can be set on the Manager by calling either `setItemSerializer` or `setCollectionSerializer`.
 
 > ##### `getItemSerializer`
 
@@ -267,7 +287,7 @@ var transformed = {
 
 #### `DataSerializer`
 
-The `DataSerializer` nests the processed resource data inside a `data` key and nests the metadata under a `meta` key.
+The `DataSerializer` nests the processed resource data inside a `data` key and nests the metadata under a `meta` key. (These keys can be customized when initializing the object by passing in a `dataKey` and/or a `metaKey` value.)
 
 ```js
 var model = {
@@ -293,6 +313,56 @@ The `ResultsMapSerializer` nests the processed resource data inside a `resultsMa
 If the processed resource is not an array, the data is returned unmodified.
 
 The identifier column can be specified in the constructor.
+
+```js
+var items = [
+    { "id" = "F29958B1-5A2B-4785-BE0A11297D0B5373", "name" = "foo" },
+    { "id" = "42A6EB0A-1196-4A76-8B9BE67422A54B26", "name" = "bar" }
+];
+
+// becomes
+
+var transformed = {
+    "results" = [
+        "F29958B1-5A2B-4785-BE0A11297D0B5373",
+        "42A6EB0A-1196-4A76-8B9BE67422A54B26"
+    ],
+    "resultsMap" = {
+        "F29958B1-5A2B-4785-BE0A11297D0B5373" = {
+            "id" = "F29958B1-5A2B-4785-BE0A11297D0B5373",
+            "name" = "foo"
+        },
+        "42A6EB0A-1196-4A76-8B9BE67422A54B26" = {
+            "id" = "42A6EB0A-1196-4A76-8B9BE67422A54B26",
+            "name" = "bar"
+        }
+    },
+    "meta" = {}
+};
+```
+
+#### `XMLSerializer`
+
+The `XMLSerializer` marshalls the data in to XML.  It nests all items under a `rootKey` which can be specified in the constructor (default is `root`). Data is returned under either a `data` key or the root transformer's `resourceKey`, if defined. Meta is returned under a `meta` key. (This can be configured in the constructor with the `metaKey` argument.)
+
+```cfc
+var model = {
+    "foo" = "bar",
+    "baz" = "qux"
+};
+
+// becomes
+
+var transformed = "
+    <root>
+        <data>
+            <foo>bar</foo>
+            <baz>qux</baz>
+        </data>
+        <meta></meta>
+    </root>
+";
+```
 
 > #### API
 

--- a/models/Scope.cfc
+++ b/models/Scope.cfc
@@ -71,21 +71,23 @@ component accessors="true" {
     *
     * @returns The transformed and serialized data.
     */
-    function convert() {
+    function convert( serialize = false ) {
         var serializer = resource.getSerializer();
+
+        if ( identifier != "" ) {
+            return serializer.scopeData( resource.process( this ), identifier );
+        }
 
         var serializedData = serializer.data( resource, this );
 
-        if ( identifier != "" ) {
-            return { "#listLast( identifier, "." )#" = serializedData };
-        }
+        serializedData = serializer.scopeRootKey( serializedData, resource.getTransformerResourceKey() );
 
         if ( resource.hasPagingData() ) {
             resource.addMeta( "pagination", resource.getPagingData() );
         }
 
         if ( resource.hasMeta() ) {
-            structAppend( serializedData, serializer.meta( resource, this ), true );
+            serializer.meta( resource, this, serializedData );
         }
 
         return serializedData;

--- a/models/Scope.cfc
+++ b/models/Scope.cfc
@@ -71,7 +71,7 @@ component accessors="true" {
     *
     * @returns The transformed and serialized data.
     */
-    function convert( serialize = false ) {
+    function convert() {
         var serializer = resource.getSerializer();
 
         if ( identifier != "" ) {

--- a/models/resources/AbstractResource.cfc
+++ b/models/resources/AbstractResource.cfc
@@ -105,20 +105,13 @@ component accessors="true" {
             item
         );
 
-        try {
-            for ( var includedDataSet in includedData ) {
-                structAppend(
-                    isNull( transformedData ) ? {} : transformedData,
-                    includedDataSet,
-                    true /* overwrite */
-                );
-            }
+        for ( var includedDataSet in includedData ) {
+            structAppend(
+                isNull( transformedData ) ? {} : transformedData,
+                includedDataSet,
+                true /* overwrite */
+            );
         }
-        catch ( any e ) {
-            writeDump( transformedData );
-            writeDump( var = includedData, abort = true );
-        }
-
 
         return isNull( transformedData ) ? javacast( "null", "" ) : transformedData;
     }

--- a/models/resources/AbstractResource.cfc
+++ b/models/resources/AbstractResource.cfc
@@ -4,10 +4,10 @@
 * @description Defines the common methods for processing
 *              resources into serializable data.
 */
-component {
+component accessors="true" {
 
     /**
-    * The item to transform into serializable data. 
+    * The item to transform into serializable data.
     */
     property name="data";
 
@@ -17,10 +17,15 @@ component {
     property name="transformer";
 
     /**
+    * The serializer used for this resource.
+    */
+    property name="serializer";
+
+    /**
     * The collection of metadata for this resource. Default: {}.
     */
     property name="meta";
-    
+
     /**
     * The paging data for this resource.
     */
@@ -57,7 +62,7 @@ component {
     * @scope   A Fractal scope instance.  Used to determinal requested
     *          includes and handle nesting identifiers.
     *
-    * @returns The transformed data. 
+    * @returns The transformed data.
     */
     function process( scope ) {
         throw(
@@ -74,7 +79,7 @@ component {
     *          includes and handle nesting identifiers.
     * @item    A single item instance to transform.
     *
-    * @returns The transformed data. 
+    * @returns The transformed data.
     */
     function processItem( scope, item ) {
         if ( isNull( item ) ) {
@@ -100,45 +105,22 @@ component {
             item
         );
 
-        for ( var includedDataSet in includedData ) {
-            structAppend(
-                isNull( transformedData ) ? {} : transformedData,
-                includedDataSet,
-                true /* overwrite */
-            );
+        try {
+            for ( var includedDataSet in includedData ) {
+                structAppend(
+                    isNull( transformedData ) ? {} : transformedData,
+                    includedDataSet,
+                    true /* overwrite */
+                );
+            }
+        }
+        catch ( any e ) {
+            writeDump( transformedData );
+            writeDump( var = includedData, abort = true );
         }
 
+
         return isNull( transformedData ) ? javacast( "null", "" ) : transformedData;
-    }
-
-    /**
-    * Returns the current serializer for the resource.
-    *
-    * @returns The current serializer.
-    */
-    function getSerializer() {
-        return variables.serializer;
-    }
-
-    /**
-    * Sets the serializer for the resource.
-    *
-    * @serializer The serializer to associate with this specific resource.
-    *
-    * @returns    The resource instance.
-    */
-    function setSerializer( serializer ) {
-        variables.serializer = arguments.serializer;
-        return this;
-    }
-
-    /**
-    * Returns the current metadata scope.
-    *
-    * @returns The metadata scope.
-    */
-    function getMeta() {
-        return variables.meta;
     }
 
     /**
@@ -164,27 +146,6 @@ component {
     }
 
     /**
-    * Returns the current paging data.
-    *
-    * @returns The paging data.
-    */
-    function getPagingData() {
-        return variables.pagingData;
-    }
-
-    /**
-    * Sets the current paging data.
-    *
-    * @pagingData The paging data to associate with this resource.
-    *
-    * @returns    The resource instance.
-    */
-    function setPagingData( pagingData ) {
-        variables.pagingData = arguments.pagingData;
-        return this;
-    }
-
-    /**
     * Returns whether any paging data has been set.
     *
     * @returns True if there is any paging data set.
@@ -206,6 +167,12 @@ component {
     function addPostTransformationCallback( callback ) {
         arrayAppend( postTransformationCallbacks, callback );
         return this;
+    }
+
+    function getTransformerResourceKey() {
+        return isClosure( variables.transformer ) ?
+            "data" :
+            variables.transformer.getResourceKey();
     }
 
     /**

--- a/models/serializers/DataSerializer.cfc
+++ b/models/serializers/DataSerializer.cfc
@@ -6,6 +6,22 @@
 component singleton {
 
     /**
+    * The key to use when scoping the data.
+    */
+    property name="metaKey";
+
+    /**
+    * The key to use when scoping the metadata.
+    */
+    property name="metaKey";
+
+    function init( dataKey = "data", metaKey = "meta" ) {
+        variables.dataKey = arguments.dataKey;
+        variables.metaKey = arguments.metaKey;
+        return this;
+    }
+
+    /**
     * Nests the data underneath a 'data' key.
     *
     * @resource The resource to serialize.
@@ -26,7 +42,7 @@ component singleton {
     * @returns    The scoped, serialized data.
     */
     function scopeData( data, identifier ) {
-        return { "#listLast( identifier, "." )#" = { "data" = data } };
+        return { "#listLast( identifier, "." )#" = { "#variables.dataKey#" = data } };
     }
 
     /**
@@ -49,7 +65,7 @@ component singleton {
     * @response The metadata nested under a "meta" key.
     */
     function meta( resource, scope, data ) {
-        structAppend( data, { "meta" = resource.getMeta() }, true );
+        structAppend( data, { "#variables.metaKey#" = resource.getMeta() }, true );
         return data;
     }
 

--- a/models/serializers/DataSerializer.cfc
+++ b/models/serializers/DataSerializer.cfc
@@ -8,7 +8,7 @@ component singleton {
     /**
     * The key to use when scoping the data.
     */
-    property name="metaKey";
+    property name="dataKey";
 
     /**
     * The key to use when scoping the metadata.

--- a/models/serializers/DataSerializer.cfc
+++ b/models/serializers/DataSerializer.cfc
@@ -18,14 +18,39 @@ component singleton {
     }
 
     /**
+    * Decides how to nest the data under the given identifier.
+    *
+    * @data       The serialized data.
+    * @identifier The current identifier for the serialization process.
+    *
+    * @returns    The scoped, serialized data.
+    */
+    function scopeData( data, identifier ) {
+        return { "#listLast( identifier, "." )#" = { "data" = data } };
+    }
+
+    /**
+    * Decides which key to use (if any) for the root of the serialized data.
+    *
+    * @data       The serialized data.
+    * @identifier The current identifier for the serialization process.
+    *
+    * @returns    The scoped, serialized data.
+    */
+    function scopeRootKey( data, identifier ) {
+        return data;
+    }
+
+    /**
     * Returns the metadata nested under a meta key.
     *
     * @data     The metadata for the response.
     *
     * @response The metadata nested under a "meta" key.
     */
-    function meta( resource, scope ) {
-        return { "meta" = resource.getMeta() };
+    function meta( resource, scope, data ) {
+        structAppend( data, { "meta" = resource.getMeta() }, true );
+        return data;
     }
 
 }

--- a/models/serializers/ResultsMapSerializer.cfc
+++ b/models/serializers/ResultsMapSerializer.cfc
@@ -66,6 +66,18 @@ component singleton {
     }
 
     /**
+    * Decides which key to use (if any) for the root of the serialized data.
+    *
+    * @data       The serialized data.
+    * @identifier The current identifier for the serialization process.
+    *
+    * @returns    The scoped, serialized data.
+    */
+    function scopeRootKey( data, identifier ) {
+        return data;
+    }
+
+    /**
     * Returns the metadata nested under a meta key.
     *
     * @data     The metadata for the response.

--- a/models/serializers/ResultsMapSerializer.cfc
+++ b/models/serializers/ResultsMapSerializer.cfc
@@ -54,6 +54,18 @@ component singleton {
     }
 
     /**
+    * Decides how to nest the data under the given identifier.
+    *
+    * @data       The serialized data.
+    * @identifier The current identifier for the serialization process.
+    *
+    * @returns    The scoped, serialized data.
+    */
+    function scopeData( data, identifier ) {
+        return { "#listLast( arguments.identifier, "." )#" = data };
+    }
+
+    /**
     * Returns the metadata nested under a meta key.
     *
     * @data     The metadata for the response.

--- a/models/serializers/ResultsMapSerializer.cfc
+++ b/models/serializers/ResultsMapSerializer.cfc
@@ -12,6 +12,11 @@ component singleton {
     property name="identitifer";
 
     /**
+    * The key to use when scoping the metadata.
+    */
+    property name="metaKey";
+
+    /**
     * Creates a new ResultMapSerializer with the given identifier.
     *
     * @identifier The key name for the identifing piece of data.
@@ -19,8 +24,9 @@ component singleton {
     *
     * @returns    The serializer instance.
     */
-    function init( identifier = "id" ) {
+    function init( identifier = "id", metaKey = "meta" ) {
         variables.identifier = arguments.identifier;
+        variables.metaKey = arguments.metaKey;
         return this;
     }
 
@@ -85,7 +91,7 @@ component singleton {
     * @response The metadata nested under a "meta" key.
     */
     function meta( resource, scope ) {
-        return { "meta" = resource.getMeta() };
+        return { "#variables.metaKey#" = resource.getMeta() };
     }
 
 }

--- a/models/serializers/SimpleSerializer.cfc
+++ b/models/serializers/SimpleSerializer.cfc
@@ -18,6 +18,30 @@ component singleton {
     }
 
     /**
+    * Decides how to nest the data under the given identifier.
+    *
+    * @data       The serialized data.
+    * @identifier The current identifier for the serialization process.
+    *
+    * @returns    The scoped, serialized data.
+    */
+    function scopeData( data, identifier ) {
+        return { "#listLast( identifier, "." )#" = data };
+    }
+
+    /**
+    * Decides which key to use (if any) for the root of the serialized data.
+    *
+    * @data       The serialized data.
+    * @identifier The current identifier for the serialization process.
+    *
+    * @returns    The scoped, serialized data.
+    */
+    function scopeRootKey( data, identifier ) {
+        return data;
+    }
+
+    /**
     * Returns the metadata nested under a meta key.
     *
     * @data     The metadata for the response.

--- a/models/serializers/XMLSerializer.cfc
+++ b/models/serializers/XMLSerializer.cfc
@@ -7,9 +7,8 @@ component singleton {
 
     property name="rootName";
 
-    function init( rootName = "root", addDataKey = true ) {
+    function init( rootName = "root" ) {
         variables.rootName = arguments.rootName;
-        variables.addDataKey = arguments.addDataKey;
         return this;
     }
 
@@ -24,7 +23,7 @@ component singleton {
     function data( resource, scope ) {
         var xmlDoc = XMLNew();
         xmlDoc.xmlRoot = XMLElemNew( xmlDoc, variables.rootName );
-        populateNode( xmlDoc.xmlRoot, resource.process( scope ) );
+        populateNode( xmlDoc.xmlRoot, resource.process( scope ), xmlDoc );
         return ToString( xmlDoc );
     }
 
@@ -68,17 +67,16 @@ component singleton {
     function meta( resource, scope, data ) {
         var xmlDoc = XMLParse( data );
         var metaNode = XMLElemNew( xmlDoc, "meta" );
-        populateNode( metaNode, resource.getMeta() );
+        populateNode( metaNode, resource.getMeta(), xmlDoc );
         arrayAppend( xmlDoc.XmlRoot.XmlChildren, metaNode );
         return ToString( xmlDoc );
     }
 
-    private function populateNode( parent, contents ) {
-        var root = xmlSearch( parent, "/*/.." )[ 1 ];
+    private function populateNode( parent, contents, root ) {
         if ( isArray( contents ) ) {
             arrayEach( contents, function( item ) {
                 var newNode = XMLElemNew( root, "item" );
-                populateNode( newNode, item );
+                populateNode( newNode, item, root );
                 arrayAppend( parent.XmlChildren, newNode );
             } );
         }
@@ -87,7 +85,7 @@ component singleton {
             arraySort( keys, "textnocase" );
             arrayEach( keys, function( key ) {
                 var newNode = XMLElemNew( root, key );
-                populateNode( newNode, contents[ key ] );
+                populateNode( newNode, contents[ key ], root );
                 arrayAppend( parent.XmlChildren, newNode );
             } );
         }

--- a/models/serializers/XMLSerializer.cfc
+++ b/models/serializers/XMLSerializer.cfc
@@ -1,14 +1,23 @@
 /**
-* @name        SimpleSerializer
+* @name        XMLSerializer
 * @package     cffractal.models.serializers
-* @description Does no further transformation to the data.
+* @description Marshalls the data to XML.
 */
 component singleton {
 
-    property name="rootName";
+    /**
+    * The key to use at the root of the XML object.
+    */
+    property name="rootKey";
 
-    function init( rootName = "root" ) {
-        variables.rootName = arguments.rootName;
+    /**
+    * The key to use when scoping the metadata.
+    */
+    property name="metaKey";
+
+    function init( rootKey = "root", metaKey = "meta" ) {
+        variables.rootKey = arguments.rootKey;
+        variables.metaKey = arguments.metaKey;
         return this;
     }
 
@@ -22,7 +31,7 @@ component singleton {
     */
     function data( resource, scope ) {
         var xmlDoc = XMLNew();
-        xmlDoc.xmlRoot = XMLElemNew( xmlDoc, variables.rootName );
+        xmlDoc.xmlRoot = XMLElemNew( xmlDoc, variables.rootKey );
         populateNode( xmlDoc.xmlRoot, resource.process( scope ), xmlDoc );
         return ToString( xmlDoc );
     }
@@ -66,7 +75,7 @@ component singleton {
     */
     function meta( resource, scope, data ) {
         var xmlDoc = XMLParse( data );
-        var metaNode = XMLElemNew( xmlDoc, "meta" );
+        var metaNode = XMLElemNew( xmlDoc, variables.metaKey );
         populateNode( metaNode, resource.getMeta(), xmlDoc );
         arrayAppend( xmlDoc.XmlRoot.XmlChildren, metaNode );
         return ToString( xmlDoc );
@@ -90,7 +99,7 @@ component singleton {
             } );
         }
         else {
-            parent.XmlText = contents;
+            parent.XmlText = encodeForXML( contents );
         }
     }
 

--- a/models/serializers/XMLSerializer.cfc
+++ b/models/serializers/XMLSerializer.cfc
@@ -1,0 +1,99 @@
+/**
+* @name        SimpleSerializer
+* @package     cffractal.models.serializers
+* @description Does no further transformation to the data.
+*/
+component singleton {
+
+    property name="rootName";
+
+    function init( rootName = "root", addDataKey = true ) {
+        variables.rootName = arguments.rootName;
+        variables.addDataKey = arguments.addDataKey;
+        return this;
+    }
+
+    /**
+    * Does no further transformation to the data.
+    *
+    * @resource The resource to serialize.
+    * @scope    A reference to the current Fractal scope.
+    *
+    * @returns  The processed resource, unnested.
+    */
+    function data( resource, scope ) {
+        var xmlDoc = XMLNew();
+        xmlDoc.xmlRoot = XMLElemNew( xmlDoc, variables.rootName );
+        populateNode( xmlDoc.xmlRoot, resource.process( scope ) );
+        return ToString( xmlDoc );
+    }
+
+    /**
+    * Decides how to nest the data under the given identifier.
+    *
+    * @data       The serialized data.
+    * @identifier The current identifier for the serialization process.
+    *
+    * @returns    The scoped, serialized data.
+    */
+    function scopeData( data, identifier ) {
+        return { "#listLast( identifier, "." )#" = data };
+    }
+
+    /**
+    * Decides which key to use (if any) for the root of the serialized data.
+    *
+    * @data       The serialized data.
+    * @identifier The current identifier for the serialization process.
+    *
+    * @returns    The scoped, serialized data.
+    */
+    function scopeRootKey( data, identifier ) {
+        var xmlDoc = XMLParse( data );
+        var currentChildren = xmlDoc.xmlRoot.XmlChildren;
+        var xmlData = XMLElemNew( xmlDoc, identifier );
+        arrayAppend( xmlData.XmlChildren, currentChildren, true );
+        arrayClear( xmlDoc.xmlRoot.XmlChildren );
+        arrayAppend( xmlDoc.xmlRoot.XmlChildren, xmlData );
+        return ToString( xmlDoc );
+    }
+
+    /**
+    * Returns the metadata nested under a meta key.
+    *
+    * @data     The metadata for the response.
+    *
+    * @response The metadata nested under a "meta" key.
+    */
+    function meta( resource, scope, data ) {
+        var xmlDoc = XMLParse( data );
+        var metaNode = XMLElemNew( xmlDoc, "meta" );
+        populateNode( metaNode, resource.getMeta() );
+        arrayAppend( xmlDoc.XmlRoot.XmlChildren, metaNode );
+        return ToString( xmlDoc );
+    }
+
+    private function populateNode( parent, contents ) {
+        var root = xmlSearch( parent, "/*/.." )[ 1 ];
+        if ( isArray( contents ) ) {
+            arrayEach( contents, function( item ) {
+                var newNode = XMLElemNew( root, "item" );
+                populateNode( newNode, item );
+                arrayAppend( parent.XmlChildren, newNode );
+            } );
+        }
+        else if ( isStruct( contents ) ) {
+            var keys = structKeyArray( contents );
+            arraySort( keys, "textnocase" );
+            arrayEach( keys, function( key ) {
+                var newNode = XMLElemNew( root, key );
+                populateNode( newNode, contents[ key ] );
+                arrayAppend( parent.XmlChildren, newNode );
+            } );
+        }
+        else {
+            parent.XmlText = contents;
+        }
+    }
+
+}

--- a/models/transformers/AbstractTransformer.cfc
+++ b/models/transformers/AbstractTransformer.cfc
@@ -19,7 +19,12 @@ component {
     **/
     property name="defaultIncludes";
     property name="availableIncludes";
-    
+
+    /**
+    * The key used to define the root level key for the serialized data.
+    */
+    variables.resourceKey = "data";
+
     /**
     * The array of default includes.
     * These includes are always return whether requested or not.
@@ -84,9 +89,32 @@ component {
         for ( var include in allIncludes ) {
             var resource = invoke( this, "include#include#", { 1 = data } );
             var childScope = scope.embedChildScope( include, resource );
-            arrayAppend( includedData, childScope.convert() );
+            arrayAppend( includedData, childScope.convert( serialize = false ) );
         }
         return includedData;
+    }
+
+    /**
+    * Returns the resource key.
+    * The resource key is used to define the root level key for the serialized data.
+    *
+    * @returns The current resource key.
+    */
+    function getResourceKey() {
+        return variables.resourceKey;
+    }
+
+    /**
+    * Returns the resource key.
+    * The resource key is used to define the root level key for the serialized data.
+    *
+    * @resourceKey The new key to use.
+    *
+    * @returns The Transformer instance.
+    */
+    function setResourceKey( resourceKey ) {
+        variables.resourceKey = arguments.resourceKey;
+        return this;
     }
 
     /**

--- a/models/transformers/AbstractTransformer.cfc
+++ b/models/transformers/AbstractTransformer.cfc
@@ -89,7 +89,7 @@ component {
         for ( var include in allIncludes ) {
             var resource = invoke( this, "include#include#", { 1 = data } );
             var childScope = scope.embedChildScope( include, resource );
-            arrayAppend( includedData, childScope.convert( serialize = false ) );
+            arrayAppend( includedData, childScope.convert() );
         }
         return includedData;
     }

--- a/tests/resources/BookTransformer.cfc
+++ b/tests/resources/BookTransformer.cfc
@@ -1,5 +1,7 @@
 component extends="cffractal.models.transformers.AbstractTransformer" {
 
+    variables.resourceKey = "book";
+
     variables.availableIncludes = [ "author" ];
 
     function transform( book ) {

--- a/tests/resources/DefaultIncludesBookTransformer.cfc
+++ b/tests/resources/DefaultIncludesBookTransformer.cfc
@@ -1,5 +1,6 @@
 component extends="cffractal.models.transformers.AbstractTransformer" {
 
+    variables.resourceKey = "book";
     variables.defaultIncludes = [ "author" ];
 
     function transform( book ) {

--- a/tests/specs/unit/ScopeTest.cfc
+++ b/tests/specs/unit/ScopeTest.cfc
@@ -19,7 +19,7 @@ component extends="testbox.system.BaseSpec" {
                         mockItem.$property( propertyName = "meta", mock = {} );
 
                         var mockSerializer = getMockBox().createMock( "cffractal.models.serializers.DataSerializer" );
-                        mockSerializer.$( "serialize", { "data" = data } );
+                        mockSerializer.$( "data", { "data" = data } );
                         mockItem.$property( propertyName = "serializer", mock = mockSerializer );
 
                         var mockFractal = getMockBox().createMock( "cffractal.models.Manager" );
@@ -31,6 +31,7 @@ component extends="testbox.system.BaseSpec" {
                     it( "with a custom transformer", function() {
                         var data = { "foo" = "bar" };
                         var mockTransformer = getMockBox().createMock( "cffractal.models.transformers.AbstractTransformer" );
+                        mockTransformer.$property( propertyName = "resourceKey", mock = "data" );
                         mockTransformer.$( "transform", data );
                         mockTransformer.$( "hasIncludes", false );
 
@@ -40,7 +41,7 @@ component extends="testbox.system.BaseSpec" {
                         mockItem.$property( propertyName = "meta", mock = {} );
 
                         var mockSerializer = getMockBox().createMock( "cffractal.models.serializers.DataSerializer" );
-                        mockSerializer.$( "serialize", { "data" = data } );
+                        mockSerializer.$( "data", { "data" = data } );
                         mockItem.$property( propertyName = "serializer", mock = mockSerializer );
 
                         var mockFractal = getMockBox().createMock( "cffractal.models.Manager" );
@@ -62,7 +63,7 @@ component extends="testbox.system.BaseSpec" {
                         mockCollection.$property( propertyName = "meta", mock = {} );
 
                         var mockSerializer = getMockBox().createMock( "cffractal.models.serializers.DataSerializer" );
-                        mockSerializer.$( "serialize", { "data" = data } );
+                        mockSerializer.$( "data", { "data" = data } );
                         mockCollection.$property( propertyName = "serializer", mock = mockSerializer );
 
                         var mockFractal = getMockBox().createMock( "cffractal.models.Manager" );
@@ -74,6 +75,7 @@ component extends="testbox.system.BaseSpec" {
                     it( "with a custom transformer", function() {
                         var data = [ { "foo" = "bar" }, { "baz" = "ban" } ];
                         var mockTransformer = getMockBox().createMock( "cffractal.models.transformers.AbstractTransformer" );
+                        mockTransformer.$property( propertyName = "resourceKey", mock = "data" );
                         mockTransformer.$( "transform" ).$args( { "foo" = "bar" } ).$results( { "foo" = "bar" } );
                         mockTransformer.$( "transform" ).$args( { "baz" = "ban" } ).$results( { "baz" = "ban" } );
                         mockTransformer.$( "hasIncludes", false );
@@ -84,7 +86,7 @@ component extends="testbox.system.BaseSpec" {
                         mockCollection.$property( propertyName = "meta", mock = {} );
 
                         var mockSerializer = getMockBox().createMock( "cffractal.models.serializers.DataSerializer" );
-                        mockSerializer.$( "serialize", { "data" = data } );
+                        mockSerializer.$( "data", { "data" = data } );
                         mockCollection.$property( propertyName = "serializer", mock = mockSerializer );
 
                         var mockFractal = getMockBox().createMock( "cffractal.models.Manager" );
@@ -105,7 +107,7 @@ component extends="testbox.system.BaseSpec" {
                         mockItem.$property( propertyName = "meta", mock = {} );
 
                         var mockSerializer = getMockBox().createMock( "cffractal.models.serializers.DataSerializer" );
-                        mockSerializer.$( "serialize", { "data" = data } );
+                        mockSerializer.$( "data", { "data" = data } );
                         mockItem.$property( propertyName = "serializer", mock = mockSerializer );
 
                         var mockFractal = getMockBox().createMock( "cffractal.models.Manager" );
@@ -117,6 +119,7 @@ component extends="testbox.system.BaseSpec" {
                     it( "with a custom transformer", function() {
                         var data = { "foo" = "bar" };
                         var mockTransformer = getMockBox().createMock( "cffractal.models.transformers.AbstractTransformer" );
+                        mockTransformer.$property( propertyName = "resourceKey", mock = "data" );
                         mockTransformer.$( "transform", data );
                         mockTransformer.$( "hasIncludes", false );
 
@@ -126,7 +129,7 @@ component extends="testbox.system.BaseSpec" {
                         mockItem.$property( propertyName = "meta", mock = {} );
 
                         var mockSerializer = getMockBox().createMock( "cffractal.models.serializers.DataSerializer" );
-                        mockSerializer.$( "serialize", { "data" = data } );
+                        mockSerializer.$( "data", { "data" = data } );
                         mockItem.$property( propertyName = "serializer", mock = mockSerializer );
 
                         var mockFractal = getMockBox().createMock( "cffractal.models.Manager" );
@@ -148,7 +151,7 @@ component extends="testbox.system.BaseSpec" {
                         mockCollection.$property( propertyName = "meta", mock = {} );
 
                         var mockSerializer = getMockBox().createMock( "cffractal.models.serializers.DataSerializer" );
-                        mockSerializer.$( "serialize", { "data" = data } );
+                        mockSerializer.$( "data", { "data" = data } );
                         mockCollection.$property( propertyName = "serializer", mock = mockSerializer );
 
                         var mockFractal = getMockBox().createMock( "cffractal.models.Manager" );
@@ -160,6 +163,7 @@ component extends="testbox.system.BaseSpec" {
                     it( "with a custom transformer", function() {
                         var data = [ { "foo" = "bar" }, { "baz" = "ban" } ];
                         var mockTransformer = getMockBox().createMock( "cffractal.models.transformers.AbstractTransformer" );
+                        mockTransformer.$property( propertyName = "resourceKey", mock = "data" );
                         mockTransformer.$( "transform" ).$args( { "foo" = "bar" } ).$results( { "foo" = "bar" } );
                         mockTransformer.$( "transform" ).$args( { "baz" = "ban" } ).$results( { "baz" = "ban" } );
                         mockTransformer.$( "hasIncludes", false );
@@ -170,7 +174,7 @@ component extends="testbox.system.BaseSpec" {
                         mockCollection.$property( propertyName = "meta", mock = {} );
 
                         var mockSerializer = getMockBox().createMock( "cffractal.models.serializers.DataSerializer" );
-                        mockSerializer.$( "serialize", { "data" = data } );
+                        mockSerializer.$( "data", { "data" = data } );
                         mockCollection.$property( propertyName = "serializer", mock = mockSerializer );
 
                         var mockFractal = getMockBox().createMock( "cffractal.models.Manager" );

--- a/tests/specs/unit/serializers/DataSerializerTest.cfc
+++ b/tests/specs/unit/serializers/DataSerializerTest.cfc
@@ -14,7 +14,7 @@ component extends="testbox.system.BaseSpec" {
                 var pagingData = { "pagination" = { "maxrows" = 50, "page" = 1, "pages" = 3, "totalRecords" = 112 } };
                 var mockScope = getMockBox().createMock( "cffractal.models.Scope" );
                 var mockItem = getMockBox().createMock( "cffractal.models.resources.Item" );
-                mockItem.$( "getMeta", pagingData );
+                mockItem.$( "getMeta", pagingData, false );
                 var serializer = new cffractal.models.serializers.DataSerializer();
                 expect( serializer.meta( mockItem, mockScope, {} ) )
                     .toBe( { "meta" = pagingData } );

--- a/tests/specs/unit/serializers/DataSerializerTest.cfc
+++ b/tests/specs/unit/serializers/DataSerializerTest.cfc
@@ -16,7 +16,7 @@ component extends="testbox.system.BaseSpec" {
                 var mockItem = getMockBox().createMock( "cffractal.models.resources.Item" );
                 mockItem.$( "getMeta", pagingData );
                 var serializer = new cffractal.models.serializers.DataSerializer();
-                expect( serializer.meta( mockItem, mockScope ) )
+                expect( serializer.meta( mockItem, mockScope, {} ) )
                     .toBe( { "meta" = pagingData } );
             } );
         } );

--- a/tests/specs/unit/serializers/ResultsMapSerializerTest.cfc
+++ b/tests/specs/unit/serializers/ResultsMapSerializerTest.cfc
@@ -32,7 +32,7 @@ component extends="testbox.system.BaseSpec" {
                 var pagingData = { "pagination" = { "maxrows" = 50, "page" = 1, "pages" = 3, "totalRecords" = 112 } };
                 var mockScope = getMockBox().createMock( "cffractal.models.Scope" );
                 var mockItem = getMockBox().createMock( "cffractal.models.resources.Item" );
-                mockItem.$( "getMeta", pagingData );
+                mockItem.$( "getMeta", pagingData, false );
                 var serializer = new cffractal.models.serializers.ResultsMapSerializer();
                 expect( serializer.meta( mockItem, mockScope ) )
                     .toBe( { "meta" = pagingData } );

--- a/tests/specs/unit/serializers/SimpleSerializerTest.cfc
+++ b/tests/specs/unit/serializers/SimpleSerializerTest.cfc
@@ -14,7 +14,7 @@ component extends="testbox.system.BaseSpec" {
                 var pagingData = { "pagination" = { "maxrows" = 50, "page" = 1, "pages" = 3, "totalRecords" = 112 } };
                 var mockScope = getMockBox().createMock( "cffractal.models.Scope" );
                 var mockItem = getMockBox().createMock( "cffractal.models.resources.Item" );
-                mockItem.$( "getMeta", pagingData );
+                mockItem.$( "getMeta", pagingData, false );
                 var serializer = new cffractal.models.serializers.SimpleSerializer();
                 expect( serializer.meta( mockItem ) ).toBe( pagingData );
             } );

--- a/tests/specs/unit/serializers/XMLSerializerTest.cfc
+++ b/tests/specs/unit/serializers/XMLSerializerTest.cfc
@@ -1,0 +1,174 @@
+component extends="testbox.system.BaseSpec" {
+    function run() {
+        describe( "xml serializer", function() {
+            beforeEach( function() {
+                variables.XMLSerializer = new cffractal.models.serializers.XMLSerializer();
+                variables.fractal = new cffractal.models.Manager( XMLSerializer, XMLSerializer, {} );
+            } );
+
+            it( "with a callback transformer", function() {
+                var book = new tests.resources.Book( {
+                    id = 1,
+                    title = "To Kill a Mockingbird",
+                    year = "1960"
+                } );
+                var resource = fractal.item( book, function( book ) {
+                    return {
+                        "id" = book.getId(),
+                        "title" = book.getTitle(),
+                        "year" = book.getYear()
+                    };
+                } );
+
+                var scope = fractal.createData( resource );
+                expect( scope.convert() ).toBe( '<?xml version="1.0" encoding="UTF-8"?>#chr(10)#<root><data><id>1</id><title>To Kill a Mockingbird</title><year>1960</year></data></root>' );
+            } );
+
+            it( "with a custom transformer", function() {
+                var book = new tests.resources.Book( {
+                    id = 1,
+                    title = "To Kill a Mockingbird",
+                    year = "1960"
+                } );
+
+                var resource = fractal.item( book, new tests.resources.BookTransformer().setManager( fractal ) );
+
+                var scope = fractal.createData( resource );
+                expect( scope.convert() ).toBe( '<?xml version="1.0" encoding="UTF-8"?>#chr(10)#<root><book><id>1</id><title>To Kill a Mockingbird</title><year>1960</year></book></root>' );
+            } );
+
+            describe( "includes", function() {
+                it( "ignores includes by default", function() {
+                    var book = new tests.resources.Book( {
+                        id = 1,
+                        title = "To Kill a Mockingbird",
+                        year = "1960",
+                        author = new tests.resources.Author( {
+                            id = 1,
+                            name = "Harper Lee",
+                            birthdate = createDate( 1926, 04, 28 )
+                        } )
+                    } );
+
+                    var resource = fractal.item( book, new tests.resources.BookTransformer().setManager( fractal ) );
+
+                    var scope = fractal.createData( resource );
+                    expect( scope.convert() ).toBe( '<?xml version="1.0" encoding="UTF-8"?>#chr(10)#<root><book><id>1</id><title>To Kill a Mockingbird</title><year>1960</year></book></root>' );
+                } );
+
+                it( "can parse an item with an includes", function() {
+                    var book = new tests.resources.Book( {
+                        id = 1,
+                        title = "To Kill a Mockingbird",
+                        year = "1960",
+                        author = new tests.resources.Author( {
+                            id = 1,
+                            name = "Harper Lee",
+                            birthdate = createDate( 1926, 04, 28 )
+                        } )
+                    } );
+
+                    var resource = fractal.item( book, new tests.resources.BookTransformer().setManager( fractal ) );
+
+                    var scope = fractal.createData( resource = resource, includes = "author" );
+                    expect( scope.convert() ).toBe( '<?xml version="1.0" encoding="UTF-8"?>#chr(10)#<root><book><author><name>Harper Lee</name></author><id>1</id><title>To Kill a Mockingbird</title><year>1960</year></book></root>' );
+                } );
+
+                it( "can parse an item with a default includes", function() {
+                    var book = new tests.resources.Book( {
+                        id = 1,
+                        title = "To Kill a Mockingbird",
+                        year = "1960",
+                        author = new tests.resources.Author( {
+                            id = 1,
+                            name = "Harper Lee",
+                            birthdate = createDate( 1926, 04, 28 )
+                        } )
+                    } );
+
+                    var resource = fractal.item( book, new tests.resources.DefaultIncludesBookTransformer().setManager( fractal ) );
+
+                    var scope = fractal.createData( resource );
+                    expect( scope.convert() ).toBe( '<?xml version="1.0" encoding="UTF-8"?>#chr(10)#<root><book><author><name>Harper Lee</name></author><id>1</id><title>To Kill a Mockingbird</title><year>1960</year></book></root>' );
+                } );
+
+                it( "can parse an item with a nested includes", function() {
+                    var book = new tests.resources.Book( {
+                        id = 1,
+                        title = "To Kill a Mockingbird",
+                        year = "1960",
+                        author = new tests.resources.Author( {
+                            id = 1,
+                            name = "Harper Lee",
+                            birthdate = createDate( 1926, 04, 28 ),
+                            country = new tests.resources.Country( {
+                                id = 1,
+                                name = "United States",
+                                planet = new tests.resources.Planet( {
+                                    id = 1,
+                                    name = "Earth"
+                                } )
+                            } )
+                        } )
+                    } );
+
+                    var resource = fractal.item( book, new tests.resources.BookTransformer().setManager( fractal ) );
+
+                    var scope = fractal.createData( resource, "author.country" );
+                    var expectedData = '<?xml version="1.0" encoding="UTF-8"?>#chr(10)#<root><book><author><country><id>1</id><name>United States</name></country><name>Harper Lee</name></author><id>1</id><title>To Kill a Mockingbird</title><year>1960</year></book></root>';
+                    expect( scope.convert() ).toBe( expectedData );
+                } );
+
+                it( "can parse an item with a deep nested includes", function() {
+                    var book = new tests.resources.Book( {
+                        id = 1,
+                        title = "To Kill a Mockingbird",
+                        year = "1960",
+                        author = new tests.resources.Author( {
+                            id = 1,
+                            name = "Harper Lee",
+                            birthdate = createDate( 1926, 04, 28 ),
+                            country = new tests.resources.Country( {
+                                id = 1,
+                                name = "United States",
+                                planet = new tests.resources.Planet( {
+                                    id = 1,
+                                    name = "Earth"
+                                } )
+                            } )
+                        } )
+                    } );
+
+                    var resource = fractal.item( book, new tests.resources.BookTransformer().setManager( fractal ) );
+
+                    var scope = fractal.createData( resource, "author.country.planet" );
+                    var expectedData = '<?xml version="1.0" encoding="UTF-8"?>#chr(10)#<root><book><author><country><id>1</id><name>United States</name><planet><id>1</id><name>Earth</name></planet></country><name>Harper Lee</name></author><id>1</id><title>To Kill a Mockingbird</title><year>1960</year></book></root>';
+                    expect( scope.convert() ).toBe( expectedData );
+                } );
+
+                it( "can automatically includes the parent when grabbing a nested include", function() {
+                    var book = new tests.resources.Book( {
+                        id = 1,
+                        title = "To Kill a Mockingbird",
+                        year = "1960",
+                        author = new tests.resources.Author( {
+                            id = 1,
+                            name = "Harper Lee",
+                            birthdate = createDate( 1926, 04, 28 ),
+                            country = new tests.resources.Country( {
+                                id = 1,
+                                name = "United States"
+                            } )
+                        } )
+                    } );
+
+                    var resource = fractal.item( book, new tests.resources.BookTransformer().setManager( fractal ) );
+
+                    var scope = fractal.createData( resource, "author.country" );
+                    var expectedData = '<?xml version="1.0" encoding="UTF-8"?>#chr(10)#<root><book><author><country><id>1</id><name>United States</name></country><name>Harper Lee</name></author><id>1</id><title>To Kill a Mockingbird</title><year>1960</year></book></root>';
+                    expect( scope.convert() ).toBe( expectedData );
+                } );
+            } );
+        } );
+    }
+}

--- a/tests/specs/unit/serializers/XMLSerializerTest.cfc
+++ b/tests/specs/unit/serializers/XMLSerializerTest.cfc
@@ -21,7 +21,7 @@ component extends="testbox.system.BaseSpec" {
                 } );
 
                 var scope = fractal.createData( resource );
-                expect( scope.convert() ).toBe( '<?xml version="1.0" encoding="UTF-8"?>#chr(10)#<root><data><id>1</id><title>To Kill a Mockingbird</title><year>1960</year></data></root>' );
+                expect( scope.convert() ).toMatch( '<root><data><id>1</id><title>To Kill a Mockingbird</title><year>1960</year></data></root>' );
             } );
 
             it( "with a custom transformer", function() {
@@ -34,7 +34,7 @@ component extends="testbox.system.BaseSpec" {
                 var resource = fractal.item( book, new tests.resources.BookTransformer().setManager( fractal ) );
 
                 var scope = fractal.createData( resource );
-                expect( scope.convert() ).toBe( '<?xml version="1.0" encoding="UTF-8"?>#chr(10)#<root><book><id>1</id><title>To Kill a Mockingbird</title><year>1960</year></book></root>' );
+                expect( scope.convert() ).toMatch( '<root><book><id>1</id><title>To Kill a Mockingbird</title><year>1960</year></book></root>' );
             } );
 
             describe( "includes", function() {
@@ -53,7 +53,7 @@ component extends="testbox.system.BaseSpec" {
                     var resource = fractal.item( book, new tests.resources.BookTransformer().setManager( fractal ) );
 
                     var scope = fractal.createData( resource );
-                    expect( scope.convert() ).toBe( '<?xml version="1.0" encoding="UTF-8"?>#chr(10)#<root><book><id>1</id><title>To Kill a Mockingbird</title><year>1960</year></book></root>' );
+                    expect( scope.convert() ).toMatch( '<root><book><id>1</id><title>To Kill a Mockingbird</title><year>1960</year></book></root>' );
                 } );
 
                 it( "can parse an item with an includes", function() {
@@ -71,7 +71,7 @@ component extends="testbox.system.BaseSpec" {
                     var resource = fractal.item( book, new tests.resources.BookTransformer().setManager( fractal ) );
 
                     var scope = fractal.createData( resource = resource, includes = "author" );
-                    expect( scope.convert() ).toBe( '<?xml version="1.0" encoding="UTF-8"?>#chr(10)#<root><book><author><name>Harper Lee</name></author><id>1</id><title>To Kill a Mockingbird</title><year>1960</year></book></root>' );
+                    expect( scope.convert() ).toMatch( '<root><book><author><name>Harper Lee</name></author><id>1</id><title>To Kill a Mockingbird</title><year>1960</year></book></root>' );
                 } );
 
                 it( "can parse an item with a default includes", function() {
@@ -89,7 +89,7 @@ component extends="testbox.system.BaseSpec" {
                     var resource = fractal.item( book, new tests.resources.DefaultIncludesBookTransformer().setManager( fractal ) );
 
                     var scope = fractal.createData( resource );
-                    expect( scope.convert() ).toBe( '<?xml version="1.0" encoding="UTF-8"?>#chr(10)#<root><book><author><name>Harper Lee</name></author><id>1</id><title>To Kill a Mockingbird</title><year>1960</year></book></root>' );
+                    expect( scope.convert() ).toMatch( '<root><book><author><name>Harper Lee</name></author><id>1</id><title>To Kill a Mockingbird</title><year>1960</year></book></root>' );
                 } );
 
                 it( "can parse an item with a nested includes", function() {
@@ -115,8 +115,8 @@ component extends="testbox.system.BaseSpec" {
                     var resource = fractal.item( book, new tests.resources.BookTransformer().setManager( fractal ) );
 
                     var scope = fractal.createData( resource, "author.country" );
-                    var expectedData = '<?xml version="1.0" encoding="UTF-8"?>#chr(10)#<root><book><author><country><id>1</id><name>United States</name></country><name>Harper Lee</name></author><id>1</id><title>To Kill a Mockingbird</title><year>1960</year></book></root>';
-                    expect( scope.convert() ).toBe( expectedData );
+                    var expectedData = '<root><book><author><country><id>1</id><name>United States</name></country><name>Harper Lee</name></author><id>1</id><title>To Kill a Mockingbird</title><year>1960</year></book></root>';
+                    expect( scope.convert() ).toMatch( expectedData );
                 } );
 
                 it( "can parse an item with a deep nested includes", function() {
@@ -142,8 +142,8 @@ component extends="testbox.system.BaseSpec" {
                     var resource = fractal.item( book, new tests.resources.BookTransformer().setManager( fractal ) );
 
                     var scope = fractal.createData( resource, "author.country.planet" );
-                    var expectedData = '<?xml version="1.0" encoding="UTF-8"?>#chr(10)#<root><book><author><country><id>1</id><name>United States</name><planet><id>1</id><name>Earth</name></planet></country><name>Harper Lee</name></author><id>1</id><title>To Kill a Mockingbird</title><year>1960</year></book></root>';
-                    expect( scope.convert() ).toBe( expectedData );
+                    var expectedData = '<root><book><author><country><id>1</id><name>United States</name><planet><id>1</id><name>Earth</name></planet></country><name>Harper Lee</name></author><id>1</id><title>To Kill a Mockingbird</title><year>1960</year></book></root>';
+                    expect( scope.convert() ).toMatch( expectedData );
                 } );
 
                 it( "can automatically includes the parent when grabbing a nested include", function() {
@@ -165,8 +165,8 @@ component extends="testbox.system.BaseSpec" {
                     var resource = fractal.item( book, new tests.resources.BookTransformer().setManager( fractal ) );
 
                     var scope = fractal.createData( resource, "author.country" );
-                    var expectedData = '<?xml version="1.0" encoding="UTF-8"?>#chr(10)#<root><book><author><country><id>1</id><name>United States</name></country><name>Harper Lee</name></author><id>1</id><title>To Kill a Mockingbird</title><year>1960</year></book></root>';
-                    expect( scope.convert() ).toBe( expectedData );
+                    var expectedData = '<root><book><author><country><id>1</id><name>United States</name></country><name>Harper Lee</name></author><id>1</id><title>To Kill a Mockingbird</title><year>1960</year></book></root>';
+                    expect( scope.convert() ).toMatch( expectedData );
                 } );
             } );
         } );


### PR DESCRIPTION
To add the `XMLSerializer` a few other changes had to be made, including a few breaking changes.  

(These are captured in the CHANGELOG.md file as well.)

## Breaking Changes

1. Custom `Serializers` now need to implement two additional methods:

#### `scopeData`
Decides how to nest the data under the given identifier. Most implementations will return the current data under the last identifier:

```
function scopeData( data, identifier ) {
    return { "#listLast( arguments.identifier, "." )#" = data };
}
```

#### `scopeRootKey`
Decides which key to use (if any) for the root of the serialized data.  For example, the `XMLSerializer` uses the new `resourceKey` to nest the root level key. (More on this new property below.)

## Improvements

1. Resources can now access their Transformer (`getTransformer`).
2. Transformers can specify a `resourceKey`.  The `resourceKey` is used by some `Serializers` to encode the root level of a Fractal request.