### PR TITLE
Change to use arrayEach()

### DIFF
--- a/models/resources/Collection.cfc
+++ b/models/resources/Collection.cfc
@@ -20,8 +20,9 @@ component extends="cffractal.models.resources.AbstractResource" {
         }
 
         var transformedDataArray = [];
-        for ( var value in data ) {
-            var transformedItem = processItem( scope, value );
+
+        arrayEach( data, function( value ){
+        	var transformedItem = processItem( scope, value );
             for ( var callback in postTransformationCallbacks ) {
                 transformedItem = paramNull(
                     callback(
@@ -36,7 +37,8 @@ component extends="cffractal.models.resources.AbstractResource" {
                 transformedDataArray,
                 transformedItem
             );
-        }
+        } );
+
         return transformedDataArray;
     }
 


### PR DESCRIPTION
Helps to prevent java.util.concurrentModificationExceptions, when looping ORM collections with shared references