### PR TITLE
XMLSerializer option to preserve key order

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,10 @@ var transformed = "
 ";
 ```
 
+##### Key Order in XML
+
+By default, `XMLSerializer` explicitly sorts all keys alphabetically since the various CF engines behave differently with respect to struct key order. If you are using ordered structs or a `LinkedHashMap` and you need the output to reflect the incoming order of the keys, you can disable the alpha sort by passing `sortKeys = false` to the constructor of `XMLSerializer` and managing the order of the keys in your transformer.  
+
 > #### API
 
 > ##### `init`

--- a/box.json
+++ b/box.json
@@ -17,7 +17,7 @@
     "dependencies":{},
     "devDependencies":{
         "coldbox":"^4.3.0+188",
-        "testbox":"^2.4.0+80"
+        "testbox":"2.4.*"
     },
     "installPaths":{
         "testbox":"testbox",

--- a/models/serializers/XMLSerializer.cfc
+++ b/models/serializers/XMLSerializer.cfc
@@ -15,9 +15,16 @@ component singleton {
     */
     property name="metaKey";
 
-    function init( rootKey = "root", metaKey = "meta" ) {
+
+    /**
+    * Do we alpha-sort the keys for XML output (default) or preserve the incoming order
+    */
+    property name="sortKeys";
+    
+    function init( rootKey = "root", metaKey = "meta", sortKeys = true ) {
         variables.rootKey = arguments.rootKey;
         variables.metaKey = arguments.metaKey;
+        variables.sortKeys = arguments.sortKeys;
         return this;
     }
 
@@ -94,7 +101,7 @@ component singleton {
         }
         else if ( isStruct( contents ) ) {
             var keys = structKeyArray( contents );
-            arraySort( keys, "textnocase" );
+            if (variables.sortKeys) arraySort( keys, "textnocase" );
             arrayEach( keys, function( key ) {
                 var newNode = XMLElemNew( root, key );
                 populateNode( newNode, contents[ key ], root );

--- a/models/serializers/XMLSerializer.cfc
+++ b/models/serializers/XMLSerializer.cfc
@@ -17,7 +17,9 @@ component singleton {
 
 
     /**
-    * Do we alpha-sort the keys for XML output (default) or preserve the incoming order
+    * Do we alpha-sort the keys for XML output (default) or preserve the incoming order.
+    * The default is to sort since using struct keys by default will come
+    * out random, especially across different engines.
     */
     property name="sortKeys";
     
@@ -101,7 +103,9 @@ component singleton {
         }
         else if ( isStruct( contents ) ) {
             var keys = structKeyArray( contents );
-            if (variables.sortKeys) arraySort( keys, "textnocase" );
+            if ( variables.sortKeys ) {
+                arraySort( keys, "textnocase" );
+            }
             arrayEach( keys, function( key ) {
                 var newNode = XMLElemNew( root, key );
                 populateNode( newNode, contents[ key ], root );

--- a/tests/resources/BookTransformer.cfc
+++ b/tests/resources/BookTransformer.cfc
@@ -3,12 +3,12 @@ component extends="cffractal.models.transformers.AbstractTransformer" {
     variables.resourceKey = "book";
     variables.availableIncludes = [ "author" ];
 
-    function init(boolean sortKeys = true) {
+    function init( sortKeys = true ) {
         variables.sortKeys = arguments.sortKeys;
     }
 
     function transform( book ) {
-        if (sortKeys) {
+        if ( sortKeys ) {
             return {
                 "id" = book.getId(),
                 "title" = book.getTitle(),
@@ -25,7 +25,10 @@ component extends="cffractal.models.transformers.AbstractTransformer" {
     }
 
     function includeAuthor( book ) {
-        return item( book.getAuthor(), new tests.resources.AuthorTransformer().setManager( manager ) );
+        return item(
+            book.getAuthor(),
+            new tests.resources.AuthorTransformer().setManager( manager )
+        );
     }
 
 }

--- a/tests/resources/BookTransformer.cfc
+++ b/tests/resources/BookTransformer.cfc
@@ -1,15 +1,27 @@
 component extends="cffractal.models.transformers.AbstractTransformer" {
 
     variables.resourceKey = "book";
-
     variables.availableIncludes = [ "author" ];
 
+    function init(boolean sortKeys = true) {
+        variables.sortKeys = arguments.sortKeys;
+    }
+
     function transform( book ) {
-        return {
-            "id" = book.getId(),
-            "title" = book.getTitle(),
-            "year" = book.getYear()
-        };
+        if (sortKeys) {
+            return {
+                "id" = book.getId(),
+                "title" = book.getTitle(),
+                "year" = book.getYear()
+            };
+        }
+        else {
+            var hashMap = createObject( "java", "java.util.LinkedHashMap" ).init();
+            hashMap[ "year" ] = "1960";
+            hashMap[ "title" ] = "To Kill a Mockingbird";
+            hashMap[ "id" ] = 1;
+            return hashMap;
+        }
     }
 
     function includeAuthor( book ) {

--- a/tests/specs/unit/serializers/XMLSerializerTest.cfc
+++ b/tests/specs/unit/serializers/XMLSerializerTest.cfc
@@ -37,6 +37,26 @@ component extends="testbox.system.BaseSpec" {
                 expect( scope.convert() ).toMatch( '<root><book><id>1</id><title>To Kill a Mockingbird</title><year>1960</year></book></root>' );
             } );
 
+            describe( "has serialization options", function() {
+                beforeEach( function() {
+                    variables.XMLSerializer = new cffractal.models.serializers.XMLSerializer( sortKeys = false );
+                    variables.fractal = new cffractal.models.Manager( XMLSerializer, XMLSerializer, {} );
+                });
+
+                it( "can preserve the order of the keys", function() {
+                    var book = new tests.resources.Book( {
+                        id = 1,
+                        title = "To Kill a Mockingbird",
+                        year = "1960"
+                    } );
+
+                    var resource = fractal.item( book, new tests.resources.BookTransformer( sortKeys = false ).setManager( fractal ) );
+
+                    var scope = fractal.createData( resource );
+                    expect( scope.convert() ).toMatch( '<root><book><year>1960</year><title>To Kill a Mockingbird</title><id>1</id></book></root>' );
+                } );  
+            });
+
             describe( "includes", function() {
                 it( "ignores includes by default", function() {
                     var book = new tests.resources.Book( {


### PR DESCRIPTION
Make sorting XML keys optional (default true)
Add test
Enable BookTransformer to work either way