### PR TITLE
Fix for includes not respecting custom serializers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 
 CFFractal in two sentences:
 
-> Views take models and return HTML.
-> CFFractal takes models and returns JSON (or your favorite serialized format).
+> Views take models and return HTML. CFFractal takes models and returns JSON (or
+> your favorite serialized format).
 
 You would want to use CFFractal if:
 
@@ -48,66 +48,80 @@ Here's some more in-depth reasons:
 
 1.  Conventions around nested resources
 
-CFFractal is able to parse your includes and excludes for you. That means no more having to litter your transformers
-with `if` statements. No more huge parameter lists. Just one argument to pass: `includes`. We'll handle the rest.
+CFFractal is able to parse your includes and excludes for you. That means no
+more having to litter your transformers with `if` statements. No more huge
+parameter lists. Just one argument to pass: `includes`. We'll handle the rest.
 
-Also, includes are in the hands of the caller. Does the caller not want the user? Great. Don't include it. Do they
-want 6 levels of nested relationships? Okay. We'll do it. Ultimate flexibility.
+Also, includes are in the hands of the caller. Does the caller not want the
+user? Great. Don't include it. Do they want 6 levels of nested relationships?
+Okay. We'll do it. Ultimate flexibility.
 
 2.  Default includes
 
-Some includes are opt-in. Others should always be included. CFFractal makes this easy while still delegating
-transformation to each resource.
+Some includes are opt-in. Others should always be included. CFFractal makes this
+easy while still delegating transformation to each resource.
 
 3.  Nested includes
 
-Do you want to get your post's author's comments? No worries! Your includes string can get that with
-`includes=author.comments`. Have more levels? Have at it!
+Do you want to get your post's author's comments? No worries! Your includes
+string can get that with `includes=author.comments`. Have more levels? Have at
+it!
 
 4.  Sharing resource transformations
 
-Adding a field to an entity? If you used CFFractal, you only need to add it to your transformer.
-Every included resource will get it automatically.
+Adding a field to an entity? If you used CFFractal, you only need to add it to
+your transformer. Every included resource will get it automatically.
 
-You have a user entity that you want to serialize, but **not ever** with the password? Just exclude it in your
-`transform()` function. All calls to CFFractal, including nested includes, will benefit from your attention to
+You have a user entity that you want to serialize, but **not ever** with the
+password? Just exclude it in your `transform()` function. All calls to
+CFFractal, including nested includes, will benefit from your attention to
 security for free.
 
 5.  Consistency
 
-It is frustrating as a consumer of an API to have to make multiple requests where one should have sufficed.
-One situation where this is sadly the case is inconsistent output between resources. Does the `user` struct
-include the `last_logged_in` key when requesting from one endpoint but not another? It is an easy mistake
-to make. CFFractal helps to reduce these mistakes by creating a single source of truth for resource
-transformations — a `Transformer`.
+It is frustrating as a consumer of an API to have to make multiple requests
+where one should have sufficed. One situation where this is sadly the case is
+inconsistent output between resources. Does the `user` struct include the
+`last_logged_in` key when requesting from one endpoint but not another? It is an
+easy mistake to make. CFFractal helps to reduce these mistakes by creating a
+single source of truth for resource transformations — a `Transformer`.
 
-Another place that is easy to mess up consistency is the response output. Is your data nested in a `data` key?
-Are you separating resources into their primary keys and a map? It's too easy to have one endpoint behave
-differently than another. In CFFractal, `Serializers` define the structure of the response and can help ensure
-a consistent output across your API endpoints.
+Another place that is easy to mess up consistency is the response output. Is
+your data nested in a `data` key? Are you separating resources into their
+primary keys and a map? It's too easy to have one endpoint behave differently
+than another. In CFFractal, `Serializers` define the structure of the response
+and can help ensure a consistent output across your API endpoints.
 
 6.  Encapsulation
 
-Playing with your model formats or your data layer code? It won't affect your API if you used CFFractal. Your
-`Transformers` are your single source of truth for model transformations. If changes need to be made, they are
-encapsulated in those files. Your API output will be unchanged from the consumer's point of view.
+Playing with your model formats or your data layer code? It won't affect your
+API if you used CFFractal. Your `Transformers` are your single source of truth
+for model transformations. If changes need to be made, they are encapsulated in
+those files. Your API output will be unchanged from the consumer's point of
+view.
 
 7.  Flexible
 
 From [Jon Clausen](https://twitter.com/jclausen):
 
-> Having written API’s against MongoDB, ORM, and even a few that use legacy DAO/Gateway patterns, the benefit for me of
-> the fractal transformation module is that I can use it for any of them, because of the transformer. If the models
-> already know how to accomplish the transformations to a degree, like our mementos in ORM, then that’s great.
+> Having written API’s against MongoDB, ORM, and even a few that use legacy
+> DAO/Gateway patterns, the benefit for me of the fractal transformation module
+> is that I can use it for any of them, because of the transformer. If the
+> models already know how to accomplish the transformations to a degree, like
+> our mementos in ORM, then that’s great.
 >
-> You don’t always have that, though, and you don’t always want a fully normalized expansion. Sometimes you need only a
-> small subset when dealing with secondary one-to-one relationships that need some normalization of the top level element.
+> You don’t always have that, though, and you don’t always want a fully
+> normalized expansion. Sometimes you need only a small subset when dealing with
+> secondary one-to-one relationships that need some normalization of the top
+> level element.
 >
-> This eliminates three methods that I always found myself writing (or copy/pasting and adapting) for every API handler:
+> This eliminates three methods that I always found myself writing (or
+> copy/pasting and adapting) for every API handler:
 >
 > 1.  The collection marshalling method
 > 2.  The single entity response marshalling method
-> 3.  The format entity method, which handles the expansion parameters in the collection
+> 3.  The format entity method, which handles the expansion parameters in the
+>     collection
 
 ### Examples
 
@@ -149,16 +163,18 @@ var transformedData = fractal.createData( resource ).toJSON();
 
 #### Manager
 
-The manager class is responsible for kicking off the transformation process. This is generally the only class you need
-to inject in you handlers. For convenience, this class is usually aliased as `fractal`.
+The manager class is responsible for kicking off the transformation process.
+This is generally the only class you need to inject in you handlers. For
+convenience, this class is usually aliased as `fractal`.
 
 ```cfc
 property name="fractal" inject="Manager@cffractal";
 ```
 
-There are three main functions to call off of fractal. The first two are factory functions: `item` and `collection`.
-These help you create fractal resources from your models, specify transformers, and set a serializer override for
-items and collections. (You can read all about those terms further down.)
+There are three main functions to call off of fractal. The first two are factory
+functions: `item` and `collection`. These help you create fractal resources from
+your models, specify transformers, and set a serializer override for items and
+collections. (You can read all about those terms further down.)
 
 > ##### `item`
 
@@ -180,8 +196,9 @@ items and collections. (You can read all about those terms further down.)
 > | transformer | AbstractTransformer or closure | true     |                                                   | The class or closure that will transform the given data                                                               |
 > | serializer  | Serializer                     | false    | The default collection serializer for the Manager | The serializer for the transformed data. If not provided, uses the default collection serializer set for the Manager. |
 
-Once you have a resource, you need to create the root scope. Scopes in `cffractal` represent the nesting level of
-the resource. Since resources can include sub-resources, we need a root scope to kick off the serializing process.
+Once you have a resource, you need to create the root scope. Scopes in
+`cffractal` represent the nesting level of the resource. Since resources can
+include sub-resources, we need a root scope to kick off the serializing process.
 You do this through the `createData` method.
 
 > ##### `createData`
@@ -194,18 +211,22 @@ You do this through the `createData` method.
 > | includes   | string           | false    | "" (empty string) | A list of includes identifiers for the serialization.                                             |
 > | identifier | string           | false    | "" (empty string) | The identifier for the current scope. Defaults to "" (empty string), also know as the root scope. |
 
-The return value is a Scope object. To finish up the serialization process, we need to call `convert` or `toJSON` on
-this object. But before we get to that, let's review the options that go in to the serialization process.
+The return value is a Scope object. To finish up the serialization process, we
+need to call `convert` or `toJSON` on this object. But before we get to that,
+let's review the options that go in to the serialization process.
 
 #### Serializers
 
-A Serializer is responsible for the shape of the response, both the data and the metadata, additional information about
-the item or collection (such as pagination or links).
+A Serializer is responsible for the shape of the response, both the data and the
+metadata, additional information about the item or collection (such as
+pagination or links).
 
-Perhaps you always want your data nested under a `data` key for consistency. Maybe you want to separate the `results` as
-an array of ids from the `resultsMap` which is the data keyed by the id. You might want a `metadata` key always present
-for any additional information, like pagination, that doesn't fit inside the normal data keys. Whatever the shape, you
-can design a serializer that can produce it.
+Perhaps you always want your data nested under a `data` key for consistency.
+Maybe you want to separate the `results` as an array of ids from the
+`resultsMap` which is the data keyed by the id. You might want a `metadata` key
+always present for any additional information, like pagination, that doesn't fit
+inside the normal data keys. Whatever the shape, you can design a serializer
+that can produce it.
 
 A serializer needs four methods:
 
@@ -233,7 +254,8 @@ A serializer needs four methods:
 
 > | Name       | Type   | Required | Default | Description                                           |
 > | ---------- | ------ | -------- | ------- | ----------------------------------------------------- |
-> | data       | any    | true     |         | The serialized data.                                  |
+> | resource   | any    | true     |         | The serializing resource.                             |
+> | scope      | any    | true     |         | The current cffractal scope.                          |
 > | identifier | string | true     |         | The current identifier for the serialization process. |
 
 > ##### `scopeRootKey`
@@ -245,13 +267,15 @@ A serializer needs four methods:
 > | data       | any    | true     |         | The serialized data.                                  |
 > | identifier | string | true     |         | The current identifier for the serialization process. |
 
-A default serializer is configured for the application when creating the Fractal manager for both `items` and
-`collections`. These can be configured separately Unless overridden, this is the serializer used for each scope
-in the serialization processes.
+A default serializer is configured for the application when creating the Fractal
+manager for both `items` and `collections`. These can be configured separately
+Unless overridden, this is the serializer used for each scope in the
+serialization processes.
 
-The current serializer for the Manager can be retrieved at any time by calling `getItemSerializer` and
-`getCollectionSerializer`. Additionally, a new default serializer can be set on the Manager by calling either
-`setItemSerializer` or `setCollectionSerializer`.
+The current serializer for the Manager can be retrieved at any time by calling
+`getItemSerializer` and `getCollectionSerializer`. Additionally, a new default
+serializer can be set on the Manager by calling either `setItemSerializer` or
+`setCollectionSerializer`.
 
 > ##### `getItemSerializer`
 
@@ -285,9 +309,11 @@ The current serializer for the Manager can be retrieved at any time by calling `
 > | ---------- | ---------- | -------- | ------- | ------------------------------------------------------ |
 > | serializer | Serializer | true     |         | The new default collection serializer for the Manager. |
 
-Also, serializers can be overridden on individual resources. The API for getting and setting serializers on resources
-is the same as it is for the Manager, but is just `getSerializer` and `setSerializer`, respectively.  A custom
-serializer can also be passed as the third argument to the `item` and `collection` factory functions.
+Also, serializers can be overridden on individual resources. The API for getting
+and setting serializers on resources is the same as it is for the Manager, but
+is just `getSerializer` and `setSerializer`, respectively. A custom serializer
+can also be passed as the third argument to the `item` and `collection` factory
+functions.
 
 ```cfc
 function includeNotes( task ) {
@@ -305,7 +331,8 @@ There are three serializers included out of the box with `cffractal`:
 
 #### `SimpleSerializer`
 
-The `SimpleSerializer` returns the processed resource data directly and nests the metadata under a `meta` key.
+The `SimpleSerializer` returns the processed resource data directly and nests
+the metadata under a `meta` key.
 
 ```cfc
 var model = {
@@ -324,8 +351,9 @@ var transformed = {
 
 #### `DataSerializer`
 
-The `DataSerializer` nests the processed resource data inside a `data` key and nests the metadata under a `meta` key.
-(These keys can be customized when initializing the object by passing in a `dataKey` and/or a `metaKey` value.)
+The `DataSerializer` nests the processed resource data inside a `data` key and
+nests the metadata under a `meta` key. (These keys can be customized when
+initializing the object by passing in a `dataKey` and/or a `metaKey` value.)
 
 ```cfc
 var model = {
@@ -346,8 +374,10 @@ var transformed = {
 
 #### `ResultsMapSerializer`
 
-The `ResultsMapSerializer` nests the processed resource data inside a `resultsMap` struct keyed by an identifier column
-as well as an array of identifiers nested under a `results` key. The metadata is nested under a `meta` key.
+The `ResultsMapSerializer` nests the processed resource data inside a
+`resultsMap` struct keyed by an identifier column as well as an array of
+identifiers nested under a `results` key. The metadata is nested under a `meta`
+key.
 
 If the processed resource is not an array, the data is returned unmodified.
 
@@ -382,9 +412,11 @@ var transformed = {
 
 #### `XMLSerializer`
 
-The `XMLSerializer` marshalls the data in to XML. It nests all items under a `rootKey` which can be specified in the
-constructor (default is `root`). Data is returned under either a `data` key or the root transformer's `resourceKey`,
-if defined. Meta is returned under a `meta` key. (This can be configured in the constructor with the `metaKey` argument.)
+The `XMLSerializer` marshalls the data in to XML. It nests all items under a
+`rootKey` which can be specified in the constructor (default is `root`). Data is
+returned under either a `data` key or the root transformer's `resourceKey`, if
+defined. Meta is returned under a `meta` key. (This can be configured in the
+constructor with the `metaKey` argument.)
 
 ```cfc
 var model = {
@@ -407,10 +439,12 @@ var transformed = "
 
 ##### Key Order in XML
 
-By default, `XMLSerializer` explicitly sorts all keys alphabetically since the various CF engines behave differently
-with respect to struct key order. If you are using ordered structs or a `LinkedHashMap` and you need the output to
-reflect the incoming order of the keys, you can disable the alpha sort by passing `sortKeys = false` to the constructor
-of `XMLSerializer` and managing the order of the keys in your transformer.
+By default, `XMLSerializer` explicitly sorts all keys alphabetically since the
+various CF engines behave differently with respect to struct key order. If you
+are using ordered structs or a `LinkedHashMap` and you need the output to
+reflect the incoming order of the keys, you can disable the alpha sort by
+passing `sortKeys = false` to the constructor of `XMLSerializer` and managing
+the order of the keys in your transformer.
 
 > #### API
 
@@ -424,11 +458,14 @@ of `XMLSerializer` and managing the order of the keys in your transformer.
 
 #### Resources
 
-Resources are a combination of your model, in whatever representation it may be in, and a transformer to take that data
-and normalize it for your API. Resources come in two flavors, `item`s and `collection`s. The API is identical for each.
-The difference comes down to how the data is processed and if pagination is considered.
+Resources are a combination of your model, in whatever representation it may be
+in, and a transformer to take that data and normalize it for your API. Resources
+come in two flavors, `item`s and `collection`s. The API is identical for each.
+The difference comes down to how the data is processed and if pagination is
+considered.
 
-You can create a resource either from the `Manager` or from inside a `Transformer`. The API is the same.
+You can create a resource either from the `Manager` or from inside a
+`Transformer`. The API is the same.
 
 > #### API
 
@@ -456,9 +493,10 @@ You can create a resource either from the `Manager` or from inside a `Transforme
 
 ##### Specifying Custom Serializers
 
-As mentioned above, individual resources can have their serializer overridden. This is useful if you only want one scope
-level to be serialized in a certain fashion (say, with the `DataSerializer`), and the rest to be serialized differently
-(say, with the `SimpleSerializer`).
+As mentioned above, individual resources can have their serializer overridden.
+This is useful if you only want one scope level to be serialized in a certain
+fashion (say, with the `DataSerializer`), and the rest to be serialized
+differently (say, with the `SimpleSerializer`).
 
 You can retrieve and set the custom serializers right from the resource.
 
@@ -480,20 +518,24 @@ You can retrieve and set the custom serializers right from the resource.
 
 ##### Transformer-level Serializers
 
-Default serializers can also be set on the `Transformer` level. If one is set, it will be passed to the `Manager`
-if no resource-level serializer is passed. This allows you to specify a serializer for an entire transformer.
-The methods to set a serializer for a `Transformer` is the same as on the `Manager`. You can set the item and
-collection serializers individually (`setItemSerializer` and `setCollectionSerializer`) or you can set both at
-the same time (`setSerializer`).
+Default serializers can also be set on the `Transformer` level. If one is set,
+it will be passed to the `Manager` if no resource-level serializer is passed.
+This allows you to specify a serializer for an entire transformer. The methods
+to set a serializer for a `Transformer` is the same as on the `Manager`. You can
+set the item and collection serializers individually (`setItemSerializer` and
+`setCollectionSerializer`) or you can set both at the same time
+(`setSerializer`).
 
 ##### Metadata
 
-CFFractal has a convention for metadata that allows the resource to add metadata items individually that are later
-combined through a serializer. For instance, the `SimpleSerializer` adds all metadata fields directly on the
-transformed object. The `DataSerializer` instead nests all of the metadata under a `meta` key. (See the serializer
-section for more details.)
+CFFractal has a convention for metadata that allows the resource to add metadata
+items individually that are later combined through a serializer. For instance,
+the `SimpleSerializer` adds all metadata fields directly on the transformed
+object. The `DataSerializer` instead nests all of the metadata under a `meta`
+key. (See the serializer section for more details.)
 
-You can add metadata directly on a resource instance. The following metadata functions are available:
+You can add metadata directly on a resource instance. The following metadata
+functions are available:
 
 > ##### `addMeta`
 >
@@ -522,9 +564,10 @@ You can add metadata directly on a resource instance. The following metadata fun
 
 ##### Post-Transformation Callbacks
 
-A powerful feature of CFFractal is the ability to add post-transformation callbacks that will fire after transforming
-each item. For an `item` resource, that means it will fire the callback once. For a `collection` resource, the callback
-will be fired for each item in the collection.
+A powerful feature of CFFractal is the ability to add post-transformation
+callbacks that will fire after transforming each item. For an `item` resource,
+that means it will fire the callback once. For a `collection` resource, the
+callback will be fired for each item in the collection.
 
 Here's an example of a post-transformation function:
 
@@ -561,23 +604,24 @@ component {
 }
 ```
 
-Using a post-transformation callback, we are able to encapsulate data about the API version without coupling it to the
-transformer itself. Sweet!
+Using a post-transformation callback, we are able to encapsulate data about the
+API version without coupling it to the transformer itself. Sweet!
 
-There are countless more usages here. **The key thing to note is that the value returned from the callback becomes the
-new transformed item.** The function API is as follows:
+There are countless more usages here. **The key thing to note is that the value
+returned from the callback becomes the new transformed item.** The function API
+is as follows:
 
 > ##### `addPostTransformationCallback`
 >
-> Add a post transformation callback to run after transforming each item.
-> The value returned from the callback becomes the transformed item.
+> Add a post transformation callback to run after transforming each item. The
+> value returned from the callback becomes the transformed item.
 >
 > | Name     | Type     | Required | Default | Description                                                                                                                                                           |
 > | -------- | -------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 > | callback | Callable | true     |         | A callback to run after the resource has been transformed. The callback will be passed the transformed data, the original data, and the resource object as arguments. |
 
-You can also specify post-transformation callbacks during resource creation as either the fourth argument or using
-the `itemCallback` argument name.
+You can also specify post-transformation callbacks during resource creation as
+either the fourth argument or using the `itemCallback` argument name.
 
 ```cfc
 // handlers/api/v1/books.cfc
@@ -613,8 +657,9 @@ component {
 
 ##### Null Default Values
 
-If the data of a resource is null or any item or include in the resource is null, CFFractal returns the Manager's
-`nullDefaultValue`. This value can be set and retrieved from the Manager as follows:
+If the data of a resource is null or any item or include in the resource is
+null, CFFractal returns the Manager's `nullDefaultValue`. This value can be set
+and retrieved from the Manager as follows:
 
 > ##### `getNullDefaultValue`
 >
@@ -632,8 +677,9 @@ If the data of a resource is null or any item or include in the resource is null
 > | ---------------- | ---- | -------- | ------- | ----------------------------------------- |
 > | nullDefaultValue | any  | true     |         | The null default value for all resources. |
 
-Additionally, this will be automatically configured for you in ColdBox to an empty string (`""`). This can be overridden
-using the `nullDefaultValue` setting in your `config/ColdBox.cfc`:
+Additionally, this will be automatically configured for you in ColdBox to an
+empty string (`""`). This can be overridden using the `nullDefaultValue` setting
+in your `config/ColdBox.cfc`:
 
 ```cfc
 function configure() {
@@ -647,15 +693,17 @@ function configure() {
 
 #### Transformers
 
-Transformers are like the view for your models. It defines how to transform your model in to a serializable representation.
+Transformers are like the view for your models. It defines how to transform your
+model in to a serializable representation.
 
 Transformers come in two flavors, closures and components.
 
 ##### Closure Transformers
 
-Closure transformers are useful for simple transformations. They are very convenient when you don't need any of the
-extra features of component transformers such as parsing includes and excludes because they are defined inline and
-very lightweight.
+Closure transformers are useful for simple transformations. They are very
+convenient when you don't need any of the extra features of component
+transformers such as parsing includes and excludes because they are defined
+inline and very lightweight.
 
 ```cfc
 fractal.item( book, function( book ) {
@@ -667,16 +715,18 @@ fractal.item( book, function( book ) {
 } );
 ```
 
-If you use a resource in more than one place or would like access to includes and excludes, you are going to want to
-use a component transformer.
+If you use a resource in more than one place or would like access to includes
+and excludes, you are going to want to use a component transformer.
 
 ##### Component Transformers
 
-Component transformers are where the power of transformers lie and will likely be the main transformer type for your API.
+Component transformers are where the power of transformers lie and will likely
+be the main transformer type for your API.
 
-Component transformers should be singleton objects that extend `cffractal.models.transformers.AbstractTransformer`.
-Mark them as such in your DI container of choice. With WireBox, it is as simple as appending the `singleton` component
-metadata attribute.
+Component transformers should be singleton objects that extend
+`cffractal.models.transformers.AbstractTransformer`. Mark them as such in your
+DI container of choice. With WireBox, it is as simple as appending the
+`singleton` component metadata attribute.
 
 ```cfc
 component extends="cffractal.models.transformers.AbstractTransformer" singleton {
@@ -690,21 +740,27 @@ component extends="cffractal.models.transformers.AbstractTransformer" singleton 
 }
 ```
 
-You might be thinking that this is no better than a closure transformer. The fact is, even in this state, we can now reuse
-this transformer without duplication! For this reason alone, you can see why most of your transformers will be components.
+You might be thinking that this is no better than a closure transformer. The
+fact is, even in this state, we can now reuse this transformer without
+duplication! For this reason alone, you can see why most of your transformers
+will be components.
 
 Component transformers get even better when we talk about includes and excludes!
 
 ##### Includes
 
-Includes are nested resources that can or should be included when serializing a resource. Let's take our book example.
+Includes are nested resources that can or should be included when serializing a
+resource. Let's take our book example.
 
-A book is written by an author and has a publisher. The author, in turn, has a country they live in.
+A book is written by an author and has a publisher. The author, in turn, has a
+country they live in.
 
-In our API endpoint, retrieving a book should always return information about the author. It should optionally return
-information about the publisher as well as the author's country.
+In our API endpoint, retrieving a book should always return information about
+the author. It should optionally return information about the publisher as well
+as the author's country.
 
-Let's set up all the models we've talked about. (This will be our most comprehensive example yet.)
+Let's set up all the models we've talked about. (This will be our most
+comprehensive example yet.)
 
 ```cfc
 component name="Book" accessors="true" {
@@ -752,8 +808,9 @@ component name="Country" accessors="true" {
 }
 ```
 
-It doesn't matter how these models are populated or how they find their relations. That's why the Transformer pattern
-is so powerful! Let's set up our transformers now so we can see how includes work.
+It doesn't matter how these models are populated or how they find their
+relations. That's why the Transformer pattern is so powerful! Let's set up our
+transformers now so we can see how includes work.
 
 ```cfc
 component name="BookTransformer" extends="cffractal.models.transformers.AbstractTransformer" singleton {
@@ -826,28 +883,35 @@ component name="PublisherTransformer" extends="cffractal.models.transformers.Abs
 }
 ```
 
-Whew. That may seem like a lot of transformers to write, but remember that this is both insulating us from changes to
-our model layer while at the same time reducing future duplication. We can now write our `authors` endpoint while
+Whew. That may seem like a lot of transformers to write, but remember that this
+is both insulating us from changes to our model layer while at the same time
+reducing future duplication. We can now write our `authors` endpoint while
 reusing our existing `AuthorsTransformer`. Neat!
 
-On to includes. There are two types of includes: `defaultIncludes` and `availableIncludes`. Both of these arrays contain
-resource names. During the transformation process, CFFractal will invoke a `include[Resource Name Here]` method on the
-transformer to retrieve the included data.
+On to includes. There are two types of includes: `defaultIncludes` and
+`availableIncludes`. Both of these arrays contain resource names. During the
+transformation process, CFFractal will invoke a `include[Resource Name Here]`
+method on the transformer to retrieve the included data.
 
-If you always want a related resource included, you want to specify it in your `defaultIncludes` array. Why would you go
-to the trouble of specifying a resource in the `defaultIncludes` array as opposed to doing it inline? Because
-`defaultIncludes` reuse existing transformers to do their transformation and serialization. We once again get to reuse
-our transformation layer with little additional effort.
+If you always want a related resource included, you want to specify it in your
+`defaultIncludes` array. Why would you go to the trouble of specifying a
+resource in the `defaultIncludes` array as opposed to doing it inline? Because
+`defaultIncludes` reuse existing transformers to do their transformation and
+serialization. We once again get to reuse our transformation layer with little
+additional effort.
 
-If you want a resource to be available to include in your transformation if a caller desired, but not included by default,
-add it to your `availableIncludes` array. This grants you the flexibility to define all the relationships and nested
-resources in the transformer while only loading them as needed. How to include available includes will be seen in detail
-in the Scope section.
+If you want a resource to be available to include in your transformation if a
+caller desired, but not included by default, add it to your `availableIncludes`
+array. This grants you the flexibility to define all the relationships and
+nested resources in the transformer while only loading them as needed. How to
+include available includes will be seen in detail in the Scope section.
 
-You might have noticed that there is no `CountryTransformer` component. Rather, we opted for a closure component for the
-`Country` resource. This probably isn't the right choice for our situation, but we opted for it here to show you that it
-is a possibility. Including it here as a closure component would mean any logic for transforming a Country outside of
-the `AuthorTransformer` component would have to be duplicated.
+You might have noticed that there is no `CountryTransformer` component. Rather,
+we opted for a closure component for the `Country` resource. This probably isn't
+the right choice for our situation, but we opted for it here to show you that it
+is a possibility. Including it here as a closure component would mean any logic
+for transforming a Country outside of the `AuthorTransformer` component would
+have to be duplicated.
 
 In the end, we get a flexible API call. If we set up our objects like this:
 
@@ -954,11 +1018,11 @@ We get a more in-depth response:
 }
 ```
 
-Includes can also handle simple data columns that are optional in your default payload.
-Your `include` method can return the simple value directly.
+Includes can also handle simple data columns that are optional in your default
+payload. Your `include` method can return the simple value directly.
 
-Let's say in our example above we wanted `pulbishedDate` to be an available include, that is,
-not included by default in our payload.
+Let's say in our example above we wanted `pulbishedDate` to be an available
+include, that is, not included by default in our payload.
 
 ```cfc
 component name="Book" accessors="true" {
@@ -1053,9 +1117,11 @@ var transformedData = fractal
 }
 ```
 
-CFFractal will also strip out any unspecified `availableIncludes` from your serialized output. With regards to the
-example above, if you did not specify `yearPublished` in the `includes`, but your `transform` method returned it
-anyway, CFFractal would remove the column before returning it to you. That means that even with the following transformer:
+CFFractal will also strip out any unspecified `availableIncludes` from your
+serialized output. With regards to the example above, if you did not specify
+`yearPublished` in the `includes`, but your `transform` method returned it
+anyway, CFFractal would remove the column before returning it to you. That means
+that even with the following transformer:
 
 ```cfc
 component name="BookTransformer" extends="cffractal.models.transformers.AbstractTransformer" singleton {
@@ -1117,9 +1183,11 @@ You would _**not**_ see the `yearPublished` key in the response:
 
 ##### Excludes
 
-Excludes are the flip side of includes.  They are used when you want to exclude something that is included _by default_.
-(It doesn't make too much sense to exclude an available include.)  There are no methods to write for excludes. They
-operate on the transformers to both skip default includes and to remove keys from the transformed output.
+Excludes are the flip side of includes. They are used when you want to exclude
+something that is included _by default_. (It doesn't make too much sense to
+exclude an available include.) There are no methods to write for excludes. They
+operate on the transformers to both skip default includes and to remove keys
+from the transformed output.
 
 Taking a look at our book example:
 
@@ -1167,8 +1235,8 @@ var transformedData = fractal.createData(
 ).toJSON();
 ```
 
-And the resulting response would _**not**_ contain the `author` key in the response.
-In fact, the `includeAuthor` method was never even called.
+And the resulting response would _**not**_ contain the `author` key in the
+response. In fact, the `includeAuthor` method was never even called.
 
 ```json
 {
@@ -1179,7 +1247,8 @@ In fact, the `includeAuthor` method was never even called.
 }
 ```
 
-Nested excludes do not affect their parent scopes as includes do.  This means that
+Nested excludes do not affect their parent scopes as includes do. This means
+that
 
 ```cfc
 var transformedData = fractal.createData(
@@ -1188,7 +1257,8 @@ var transformedData = fractal.createData(
 ).toJSON();
 ```
 
-Does not exclude the `author` entirely, but rather removes a key from the transformed author response.
+Does not exclude the `author` entirely, but rather removes a key from the
+transformed author response.
 
 ```json
 {
@@ -1204,14 +1274,15 @@ Does not exclude the `author` entirely, but rather removes a key from the transf
 }
 ```
 
-As seen in the example above, excludes can also target normal properties of the transformed response to remove.
-They do not have to be includes.
+As seen in the example above, excludes can also target normal properties of the
+transformed response to remove. They do not have to be includes.
 
 ###### Includes and Excludes in Transformers
 
-Both types of transformers have access to the includes and excludes of the currently executing scope as well as the
-includes and excludes of the entire transformation. These are passed as arrays of scopes to the next four
-arguments to a transformer and each include method.
+Both types of transformers have access to the includes and excludes of the
+currently executing scope as well as the includes and excludes of the entire
+transformation. These are passed as arrays of scopes to the next four arguments
+to a transformer and each include method.
 
 ```
 component name="BookTransformer" extends="cffractal.models.transformers.AbstractTransformer" singleton {
@@ -1236,25 +1307,29 @@ component name="BookTransformer" extends="cffractal.models.transformers.Abstract
 }
 ```
 
-Scoped includes and excludes are ones that are pertinent to the current level of transformation.  You won't find any
-nested scopes in those arguments.  For instance, with a includes string of `author.name`, the `AuthorTransformer` would
+Scoped includes and excludes are ones that are pertinent to the current level of
+transformation. You won't find any nested scopes in those arguments. For
+instance, with a includes string of `author.name`, the `AuthorTransformer` would
 be passed `[ "name" ]` in its scoped includes.
 
 ##### Custom Managers
 
-By default the "Manager" of your transformer defaults to `Manager@cffractal`. A `setManager()` method is available in
-your transformers, which allows you to specific a custom manager. This manager, however, must implement the methods
+By default the "Manager" of your transformer defaults to `Manager@cffractal`. A
+`setManager()` method is available in your transformers, which allows you to
+specific a custom manager. This manager, however, must implement the methods
 found in `cffractal.models.Manager`.
 
 #### Scope
 
-Scope is the last piece of the CFFractal puzzle. A `Scope` is a resource combined with any includes and a scope identifier.
-The scope identifier represents the current nesting level of the resource transformation. A scope identifier of `""`
-(an empty string) represents the root level of the resource. As includes are processed, additional scopes are created
-with the correctly scoped includes to continue the transformation and serialization processes.
+Scope is the last piece of the CFFractal puzzle. A `Scope` is a resource
+combined with any includes and a scope identifier. The scope identifier
+represents the current nesting level of the resource transformation. A scope
+identifier of `""` (an empty string) represents the root level of the resource.
+As includes are processed, additional scopes are created with the correctly
+scoped includes to continue the transformation and serialization processes.
 
-This concept is especially important for nested includes. In the example right before this section, there was an example
-of a nested include:
+This concept is especially important for nested includes. In the example right
+before this section, there was an example of a nested include:
 
 ```cfc
 var transformedData = fractal
@@ -1265,27 +1340,38 @@ var transformedData = fractal
     .toJSON();
 ```
 
-This is asking CFFractal to include the resource's author and that author's country. In fact, `author` doesn't even
-need to be in the `defaultIncludes` array to be included in this case. Included a nested resource will include all of
-it's parent resources as well. (It does, however, at least need to be in the `availableIncludes` array to do anything.)
+This is asking CFFractal to include the resource's author and that author's
+country. In fact, `author` doesn't even need to be in the `defaultIncludes`
+array to be included in this case. Included a nested resource will include all
+of it's parent resources as well. (It does, however, at least need to be in the
+`availableIncludes` array to do anything.)
 
 Let's step through this example to understand how it works.
 
 1.  The resource tries to resolve the `"author"` include.
-2.  It finds it on the `BookTransformer` and creates a new resource and embeds it in a new child scope where the scope identifier is `"author"`, the current include name.
-3.  The includes are then evaluated against the current scope identifier. While `"country"` is not a valid include from the root scope (`"book"`), in this child scope (`"author"`) `"country"` is a valid include.
-4.  `"country"` is processed under a further nested child scope with a scope identifier of `"country"`.
-5.  As this is the last step of the includes chain, each child scope is transformed, serialized, and then placed inside a key matching the scope identifier in its parent scope.
+2.  It finds it on the `BookTransformer` and creates a new resource and embeds
+    it in a new child scope where the scope identifier is `"author"`, the
+    current include name.
+3.  The includes are then evaluated against the current scope identifier. While
+    `"country"` is not a valid include from the root scope (`"book"`), in this
+    child scope (`"author"`) `"country"` is a valid include.
+4.  `"country"` is processed under a further nested child scope with a scope
+    identifier of `"country"`.
+5.  As this is the last step of the includes chain, each child scope is
+    transformed, serialized, and then placed inside a key matching the scope
+    identifier in its parent scope.
 
-Scopes, while important, are mostly invisible in the CFFractal process. The root scope is created by the initial call
-to `createData` and child scopes are created inside the transformation process for you. Still, it is important to visualize
-the includes chain to help you when designing your transformers.
+Scopes, while important, are mostly invisible in the CFFractal process. The root
+scope is created by the initial call to `createData` and child scopes are
+created inside the transformation process for you. Still, it is important to
+visualize the includes chain to help you when designing your transformers.
 
 #### Builder
 
-It is important to know the piece of CFFractal so you can use the full power of the library. But it can seem a bit verbose.
-To help alleviate this, CFFractal has a `Builder` class to help reduce boilerplate by leveraging conventions.
-(You also might find that you just like the syntax better.)
+It is important to know the piece of CFFractal so you can use the full power of
+the library. But it can seem a bit verbose. To help alleviate this, CFFractal
+has a `Builder` class to help reduce boilerplate by leveraging conventions. (You
+also might find that you just like the syntax better.)
 
 The `Builder` component turns code like this:
 
@@ -1346,8 +1432,9 @@ var result = fractal.builder()
 // {"data":{"id":1,"title":"To Kill A Mockingbird","author":{"name":"Harper Lee","year":"1926"},"links":{"uri":"/books/1"}}}
 ```
 
-The `Builder` component uses the same API under the hood, but you may find the flow more to your sensibilities.
-Additionally, the `withTransformer` and `withSerializer` methods will look up simple strings as WireBox mappings,
+The `Builder` component uses the same API under the hood, but you may find the
+flow more to your sensibilities. Additionally, the `withTransformer` and
+`withSerializer` methods will look up simple strings as WireBox mappings,
 streamlining your code even more.
 
 The `Builder` has the following methods:
@@ -1372,7 +1459,8 @@ The `Builder` has the following methods:
 
 > ##### `withTransformer`
 >
-> Sets the transformer to use. If the transformer is a simple value, the Builder will treat it as a WireBox binding.
+> Sets the transformer to use. If the transformer is a simple value, the Builder
+> will treat it as a WireBox binding.
 >
 > | Name        | Type | Required | Default | Description             |
 > | ----------- | ---- | -------- | ------- | ----------------------- |
@@ -1380,7 +1468,8 @@ The `Builder` has the following methods:
 
 > ##### `withSerializer`
 >
-> Sets the serializer to use. If the serializer is a simple value, the Builder will treat it as a WireBox binding.
+> Sets the serializer to use. If the serializer is a simple value, the Builder
+> will treat it as a WireBox binding.
 >
 > | Name       | Type | Required | Default | Description            |
 > | ---------- | ---- | -------- | ------- | ---------------------- |
@@ -1447,4 +1536,5 @@ The `Builder` has the following methods:
 
 #### Have Questions?
 
-Come find us on the [CFML Slack]() (#box-products channel) and ask us there. We'd be happy to help!
+Come find us on the [CFML Slack]() (#box-products channel) and ask us there.
+We'd be happy to help!

--- a/models/Scope.cfc
+++ b/models/Scope.cfc
@@ -146,7 +146,7 @@ component accessors="true" {
         var serializer = resource.getSerializer();
 
         if ( identifier != "" ) {
-            return serializer.scopeData( resource.process( this ), identifier );
+            return serializer.scopeData( resource, this, identifier );
         }
 
         var serializedData = serializer.data( resource, this );

--- a/models/serializers/DataSerializer.cfc
+++ b/models/serializers/DataSerializer.cfc
@@ -36,13 +36,24 @@ component singleton {
     /**
     * Decides how to nest the data under the given identifier.
     *
-    * @data       The serialized data.
+    * @resource   The serializing resource.
+    * @scope      The current cffractal scope..
     * @identifier The current identifier for the serialization process.
     *
     * @returns    The scoped, serialized data.
     */
-    function scopeData( data, identifier ) {
-        return { "#listLast( identifier, "." )#" = { "#variables.dataKey#" = data } };
+    function scopeData( resource, scope, identifier ) {
+        var serializedData = data( resource, scope );
+
+        if ( resource.hasPagingData() ) {
+            resource.addMeta( "pagination", resource.getPagingData() );
+        }
+
+        if ( resource.hasMeta() ) {
+            meta( resource, scope, serializedData );
+        }
+
+        return { "#listLast( identifier, "." )#" = serializedData };
     }
 
     /**

--- a/models/serializers/ResultsMapSerializer.cfc
+++ b/models/serializers/ResultsMapSerializer.cfc
@@ -62,13 +62,24 @@ component singleton {
     /**
     * Decides how to nest the data under the given identifier.
     *
-    * @data       The serialized data.
+    * @resource   The serializing resource.
+    * @scope      The current cffractal scope..
     * @identifier The current identifier for the serialization process.
     *
     * @returns    The scoped, serialized data.
     */
-    function scopeData( data, identifier ) {
-        return { "#listLast( arguments.identifier, "." )#" = data };
+    function scopeData( resource, scope, identifier ) {
+        var serializedData = data( resource, scope );
+
+        if ( resource.hasPagingData() ) {
+            resource.addMeta( "pagination", resource.getPagingData() );
+        }
+
+        if ( resource.hasMeta() ) {
+            meta( resource, scope, serializedData );
+        }
+
+        return { "#listLast( arguments.identifier, "." )#" = serializedData };
     }
 
     /**

--- a/models/serializers/SimpleSerializer.cfc
+++ b/models/serializers/SimpleSerializer.cfc
@@ -20,13 +20,24 @@ component singleton {
     /**
     * Decides how to nest the data under the given identifier.
     *
-    * @data       The serialized data.
+    * @resource   The serializing resource.
+    * @scope      The current cffractal scope..
     * @identifier The current identifier for the serialization process.
     *
     * @returns    The scoped, serialized data.
     */
-    function scopeData( data, identifier ) {
-        return { "#listLast( identifier, "." )#" = data };
+    function scopeData( resource, scope, identifier ) {
+        var serializedData = data( resource, scope );
+
+        if ( resource.hasPagingData() ) {
+            resource.addMeta( "pagination", resource.getPagingData() );
+        }
+
+        if ( resource.hasMeta() ) {
+            meta( resource, scope, serializedData );
+        }
+
+        return { "#listLast( identifier, "." )#" = serializedData };
     }
 
     /**

--- a/models/serializers/XMLSerializer.cfc
+++ b/models/serializers/XMLSerializer.cfc
@@ -22,7 +22,7 @@ component singleton {
     * out random, especially across different engines.
     */
     property name="sortKeys";
-    
+
     function init( rootKey = "root", metaKey = "meta", sortKeys = true ) {
         variables.rootKey = arguments.rootKey;
         variables.metaKey = arguments.metaKey;
@@ -48,12 +48,14 @@ component singleton {
     /**
     * Decides how to nest the data under the given identifier.
     *
-    * @data       The serialized data.
+    * @resource   The serializing resource.
+    * @scope      The current cffractal scope..
     * @identifier The current identifier for the serialization process.
     *
     * @returns    The scoped, serialized data.
     */
-    function scopeData( data, identifier ) {
+    function scopeData( resource, scope, identifier ) {
+        var data = resource.process( scope );
         return { "#listLast( identifier, "." )#" = data };
     }
 

--- a/tests/resources/Author.cfc
+++ b/tests/resources/Author.cfc
@@ -4,6 +4,7 @@ component accessors="true" {
     property name="name";
     property name="birthdate";
     property name="country";
+    property name="books";
 
     function init( struct args = {} ) {
         for ( var arg in args ) {

--- a/tests/resources/AuthorTransformer.cfc
+++ b/tests/resources/AuthorTransformer.cfc
@@ -1,11 +1,19 @@
 component extends="cffractal.models.transformers.AbstractTransformer" {
 
-    variables.availableIncludes = [ "country" ];
+    variables.availableIncludes = [ "country", "books" ];
 
     function transform( author ) {
         return {
             "name" = author.getName()
         };
+    }
+
+    function includeBooks( author ) {
+        return collection(
+            author.getBooks(),
+            new tests.resources.BookTransformer().setManager( manager ),
+            new cffractal.models.serializers.ResultsMapSerializer()
+        );
     }
 
     function includeCountry( author ) {

--- a/tests/specs/integration/FractalBuilderTest.cfc
+++ b/tests/specs/integration/FractalBuilderTest.cfc
@@ -188,6 +188,54 @@ component extends="testbox.system.BaseSpec" {
                             };
                             expect( result ).toBe( expectedData );
                         } );
+
+                        it( "can handle an includes that returns a collection", function() {
+                            var author = new tests.resources.Author( {
+                                id = 1,
+                                name = "Harper Lee",
+                                birthdate = createDate( 1926, 04, 28 ),
+                                books = [
+                                    new tests.resources.Book( {
+                                        id = 1,
+                                        title = "To Kill a Mockingbird",
+                                        year = "1960"
+                                    } ),
+                                    new tests.resources.Book( {
+                                        id = 2,
+                                        title = "Go Set a Watchman",
+                                        year = "2015"
+                                    } )
+                                ]
+                            } );
+
+                            var result = fractal.builder()
+                                .item( author )
+                                .withIncludes( "books" )
+                                .withTransformer( new tests.resources.AuthorTransformer().setManager( fractal ) )
+                                .convert();
+
+                            var expectedData = {
+                                "data" = {
+                                    "name" = "Harper Lee",
+                                    "books" = {
+                                        "results" = [ 1, 2 ],
+                                        "resultsMap" = {
+                                            "1" = {
+                                                "id" = 1,
+                                                "year" = 1960,
+                                                "title" = "To Kill a Mockingbird"
+                                            },
+                                            "2" = {
+                                                "id" = 2,
+                                                "year" = 2015,
+                                                "title" = "Go Set a Watchman"
+                                            }
+                                        }
+                                    }
+                                }
+                            };
+                            expect( result ).toBe( expectedData );
+                        } );
                     } );
 
                     describe( "excludes", function() {

--- a/tests/specs/integration/FractalTest.cfc
+++ b/tests/specs/integration/FractalTest.cfc
@@ -524,12 +524,10 @@ component extends="testbox.system.BaseSpec" {
                             expect( callLog ).toHaveKey( "transform" );
                             var transformCallLog = callLog.transform;
                             expect( transformCallLog ).toBeArray();
-                            expect( transformCallLog ).toHaveLength( 1 );
                             var firstCall = transformCallLog[ 1 ];
                             expect( arrayLen( firstCall ) ).toBeGTE( 2, "At least two arguments should be passed to the transform function" );
                             var scopedIncludes = firstCall[ 2 ];
                             expect( scopedIncludes ).toBeArray();
-                            expect( scopedIncludes ).toHaveLength( 2 );
                             expect( scopedIncludes ).toBe( [ "year", "author" ] );
 
                             // Author Transformer
@@ -538,12 +536,10 @@ component extends="testbox.system.BaseSpec" {
                             expect( callLog ).toHaveKey( "transform" );
                             var transformCallLog = callLog.transform;
                             expect( transformCallLog ).toBeArray();
-                            expect( transformCallLog ).toHaveLength( 1 );
                             var firstCall = transformCallLog[ 1 ];
                             expect( arrayLen( firstCall ) ).toBeGTE( 2, "At least two arguments should be passed to the transform function" );
                             var scopedIncludes = firstCall[ 2 ];
                             expect( scopedIncludes ).toBeArray();
-                            expect( scopedIncludes ).toHaveLength( 1 );
                             expect( scopedIncludes ).toBe( [ "name" ] );
                         } );
 
@@ -576,12 +572,10 @@ component extends="testbox.system.BaseSpec" {
                             expect( callLog ).toHaveKey( "transform" );
                             var transformCallLog = callLog.transform;
                             expect( transformCallLog ).toBeArray();
-                            expect( transformCallLog ).toHaveLength( 1 );
                             var firstCall = transformCallLog[ 1 ];
                             expect( arrayLen( firstCall ) ).toBeGTE( 4, "At least four arguments should be passed to the transform function" );
                             var allIncludes = firstCall[ 4 ];
                             expect( allIncludes ).toBeArray();
-                            expect( allIncludes ).toHaveLength( 3 );
                             expect( allIncludes ).toBe( [ "year", "author.name", "author" ] );
 
                             // Author Transformer
@@ -590,12 +584,10 @@ component extends="testbox.system.BaseSpec" {
                             expect( callLog ).toHaveKey( "transform" );
                             var transformCallLog = callLog.transform;
                             expect( transformCallLog ).toBeArray();
-                            expect( transformCallLog ).toHaveLength( 1 );
                             var firstCall = transformCallLog[ 1 ];
                             expect( arrayLen( firstCall ) ).toBeGTE( 4, "At least four arguments should be passed to the transform function" );
                             var allIncludes = firstCall[ 4 ];
                             expect( allIncludes ).toBeArray();
-                            expect( allIncludes ).toHaveLength( 3 );
                             expect( allIncludes ).toBe( [ "year", "author.name", "author" ] );
                         } );
                     } );
@@ -860,12 +852,10 @@ component extends="testbox.system.BaseSpec" {
                             expect( callLog ).toHaveKey( "transform" );
                             var transformCallLog = callLog.transform;
                             expect( transformCallLog ).toBeArray();
-                            expect( transformCallLog ).toHaveLength( 1 );
                             var firstCall = transformCallLog[ 1 ];
                             expect( arrayLen( firstCall ) ).toBeGTE( 3, "At least three arguments should be passed to the transform function" );
                             var scopedExcludes = firstCall[ 3 ];
                             expect( scopedExcludes ).toBeArray();
-                            expect( scopedExcludes ).toHaveLength( 1 );
                             expect( scopedExcludes ).toBe( [ "year" ] );
 
                             // Author Transformer
@@ -874,12 +864,10 @@ component extends="testbox.system.BaseSpec" {
                             expect( callLog ).toHaveKey( "transform" );
                             var transformCallLog = callLog.transform;
                             expect( transformCallLog ).toBeArray();
-                            expect( transformCallLog ).toHaveLength( 1 );
                             var firstCall = transformCallLog[ 1 ];
                             expect( arrayLen( firstCall ) ).toBeGTE( 3, "At least three arguments should be passed to the transform function" );
                             var scopedExcludes = firstCall[ 3 ];
                             expect( scopedExcludes ).toBeArray();
-                            expect( scopedExcludes ).toHaveLength( 1 );
                             expect( scopedExcludes ).toBe( [ "name" ] );
                         } );
 
@@ -913,12 +901,10 @@ component extends="testbox.system.BaseSpec" {
                             expect( callLog ).toHaveKey( "transform" );
                             var transformCallLog = callLog.transform;
                             expect( transformCallLog ).toBeArray();
-                            expect( transformCallLog ).toHaveLength( 1 );
                             var firstCall = transformCallLog[ 1 ];
                             expect( arrayLen( firstCall ) ).toBeGTE( 5, "At least five arguments should be passed to the transform function" );
                             var allIncludes = firstCall[ 5 ];
                             expect( allIncludes ).toBeArray();
-                            expect( allIncludes ).toHaveLength( 2 );
                             expect( allIncludes ).toBe( [ "year", "author.name" ] );
 
                             // Author Transformer
@@ -927,12 +913,10 @@ component extends="testbox.system.BaseSpec" {
                             expect( callLog ).toHaveKey( "transform" );
                             var transformCallLog = callLog.transform;
                             expect( transformCallLog ).toBeArray();
-                            expect( transformCallLog ).toHaveLength( 1 );
                             var firstCall = transformCallLog[ 1 ];
                             expect( arrayLen( firstCall ) ).toBeGTE( 5, "At least five arguments should be passed to the transform function" );
                             var allIncludes = firstCall[ 5 ];
                             expect( allIncludes ).toBeArray();
-                            expect( allIncludes ).toHaveLength( 2 );
                             expect( allIncludes ).toBe( [ "year", "author.name" ] );
                         } );
                     } );


### PR DESCRIPTION
Previously includes would ignore custom serializers.  This
should now be accomplished in the `scopeData` method.
It would be nice to pull this out to `Scope` at one point, but
right now that messes a lot with the `XmlSerializer`.

BREAKING CHANGE: This changes the interface of the `scopeData` method
in serializers.  It now accepts three arguments — `resource`, `scope`, and `identifier`.