### PR TITLE
Ignore non-struct data when excluding keys

### DIFF
--- a/models/resources/AbstractResource.cfc
+++ b/models/resources/AbstractResource.cfc
@@ -235,8 +235,10 @@ component accessors="true" {
     * @returns           The transformed data without any excluded keys.
     */
     private function removeExcludes( transformedData, excludes ) {
-        for ( var exclude in excludes ) {
-            structDelete( transformedData, exclude );
+        if ( isStruct( transformedData ) && ! isObject( transformedData ) ) {
+            for ( var exclude in excludes ) {
+                structDelete( transformedData, exclude );
+            }
         }
         return transformedData;
     }

--- a/tests/resources/DefaultIncludesBookTransformer.cfc
+++ b/tests/resources/DefaultIncludesBookTransformer.cfc
@@ -1,7 +1,7 @@
 component extends="cffractal.models.transformers.AbstractTransformer" {
 
     variables.resourceKey = "book";
-    variables.defaultIncludes = [ "author" ];
+    variables.defaultIncludes = [ "author", "bookCount" ];
 
     function init( withDefaultCountry = false ) {
         variables.withDefaultCountry = arguments.withDefaultCountry;
@@ -21,6 +21,10 @@ component extends="cffractal.models.transformers.AbstractTransformer" {
             book.getAuthor(),
             new tests.resources.DefaultIncludesAuthorTransformer( withDefaultCountry ).setManager( manager )
         );
+    }
+
+    function includeBookCount( book ) {
+        return 4;
     }
 
 }

--- a/tests/specs/integration/FractalBuilderTest.cfc
+++ b/tests/specs/integration/FractalBuilderTest.cfc
@@ -100,7 +100,7 @@ component extends="testbox.system.BaseSpec" {
                                 .withTransformer( new tests.resources.DefaultIncludesBookTransformer().setManager( fractal ) )
                                 .convert();
 
-                            expect( result ).toBe( {"data":{"year":1960,"title":"To Kill a Mockingbird","id":1,"author":{"data":{"name":"Harper Lee"}}}} );
+                            expect( result ).toBe( {"data":{"year":1960,"title":"To Kill a Mockingbird","id":1,"bookCount":4,"author":{"data":{"name":"Harper Lee"}}}} );
                         } );
 
                         it( "can parse an item with a nested includes", function() {
@@ -257,7 +257,7 @@ component extends="testbox.system.BaseSpec" {
                                 .withExcludes( "author" )
                                 .convert();
 
-                            expect( result ).toBe( {"data":{"year":1960,"title":"To Kill a Mockingbird","id":1}} );
+                            expect( result ).toBe( {"data":{"year":1960,"title":"To Kill a Mockingbird","id":1,"bookCount":4}} );
                         } );
                     } );
                 } );

--- a/tests/specs/integration/FractalTest.cfc
+++ b/tests/specs/integration/FractalTest.cfc
@@ -263,7 +263,7 @@ component extends="testbox.system.BaseSpec" {
                             var resource = fractal.item( book, new tests.resources.DefaultIncludesBookTransformer().setManager( fractal ) );
 
                             var scope = fractal.createData( resource );
-                            expect( scope.convert() ).toBe( {"data":{"year":1960,"title":"To Kill a Mockingbird","id":1,"author":{"data":{"name":"Harper Lee"}}}} );
+                            expect( scope.convert() ).toBe( {"data":{"year":1960,"title":"To Kill a Mockingbird","id":1,"bookCount":4,"author":{"data":{"name":"Harper Lee"}}}} );
                         } );
 
                         it( "can use a special serializer for an include", function() {
@@ -611,7 +611,7 @@ component extends="testbox.system.BaseSpec" {
                                 resource = resource,
                                 excludes = "author"
                             );
-                            expect( scope.convert() ).toBe( {"data":{"year":1960,"title":"To Kill a Mockingbird","id":1}} );
+                            expect( scope.convert() ).toBe( {"data":{"year":1960,"title":"To Kill a Mockingbird","id":1,"bookCount":4}} );
                         } );
 
                         it( "can ignore a nested default include", function() {
@@ -649,7 +649,8 @@ component extends="testbox.system.BaseSpec" {
                                         "data" = {
                                             "name" = "Harper Lee"
                                         }
-                                    }
+                                    },
+                                    "bookCount" = 4
                                 }
                             };
                             expect( scope.convert() ).toBe( expectedData );
@@ -730,6 +731,7 @@ component extends="testbox.system.BaseSpec" {
                                     "year" = 1960,
                                     "title" = "To Kill a Mockingbird",
                                     "id" = 1,
+                                    "bookCount" = 4,
                                     "author" = {
                                         "data" = {
                                             "name" = "Harper Lee",

--- a/tests/specs/unit/serializers/XMLSerializerTest.cfc
+++ b/tests/specs/unit/serializers/XMLSerializerTest.cfc
@@ -54,7 +54,7 @@ component extends="testbox.system.BaseSpec" {
 
                     var scope = fractal.createData( resource );
                     expect( scope.convert() ).toMatch( '<root><book><year>1960</year><title>To Kill a Mockingbird</title><id>1</id></book></root>' );
-                } );  
+                } );
             });
 
             describe( "includes", function() {
@@ -109,7 +109,7 @@ component extends="testbox.system.BaseSpec" {
                     var resource = fractal.item( book, new tests.resources.DefaultIncludesBookTransformer().setManager( fractal ) );
 
                     var scope = fractal.createData( resource );
-                    expect( scope.convert() ).toMatch( '<root><book><author><name>Harper Lee</name></author><id>1</id><title>To Kill a Mockingbird</title><year>1960</year></book></root>' );
+                    expect( scope.convert() ).toMatch( '<root><book><author><name>Harper Lee</name></author><bookCount>4</bookCount><id>1</id><title>To Kill a Mockingbird</title><year>1960</year></book></root>' );
                 } );
 
                 it( "can parse an item with a nested includes", function() {


### PR DESCRIPTION
If an include returns a simple value, ignore it when looking for keys
to remove.