### PR TITLE
Allow for a variable array separator in XML serialization other than …

### DIFF
--- a/models/serializers/XMLSerializer.cfc
+++ b/models/serializers/XMLSerializer.cfc
@@ -23,10 +23,16 @@ component singleton {
     */
     property name="sortKeys";
 
-    function init( rootKey = "root", metaKey = "meta", sortKeys = true ) {
+     /**
+    * The separator key to use when serializing an array. Default "item"
+    */
+    property name="itemKey";
+
+    function init( rootKey = "root", metaKey = "meta", sortKeys = true, itemKey = "item" ) {
         variables.rootKey = arguments.rootKey;
         variables.metaKey = arguments.metaKey;
         variables.sortKeys = arguments.sortKeys;
+        variables.itemKey = arguments.itemKey;
         return this;
     }
 
@@ -98,7 +104,7 @@ component singleton {
     private function populateNode( parent, contents, root ) {
         if ( isArray( contents ) ) {
             arrayEach( contents, function( item ) {
-                var newNode = XMLElemNew( root, "item" );
+                var newNode = XMLElemNew( root, variables.itemKey );
                 populateNode( newNode, item, root );
                 arrayAppend( parent.XmlChildren, newNode );
             } );


### PR DESCRIPTION
The use case for this is pretty convoluted but when serializing XML using linked hashed maps, you can't use cffractal's awesome "includes" ability because it will put the results wherever it wants in the resulting XML; so you have serialize any sub-entities in the parent transformer.

If you have an XML node with multiple children, it's a bear getting the naming scheme exactly how you want since cffractal assumes you'll just create resources that look like what you want in an include. 

This change let us designate the separator node name when serializing arrays into XML in cases where we (or, more accurately, the awful provider of an XML-based API we have to use) has an explicit ordering requirement and doesn't want <item> in there.